### PR TITLE
Optimizations to IrisGL

### DIFF
--- a/src/editor/editorcameracontroller.cpp
+++ b/src/editor/editorcameracontroller.cpp
@@ -41,11 +41,11 @@ void EditorCameraController::setCamera(CameraNodePtr cam)
 {
     this->camera = cam;
 
-    auto viewVec = cam->rot.rotatedVector(QVector3D(0,0,-1));//default forward is -z
+    auto viewVec = cam->getLocalRot().rotatedVector(QVector3D(0,0,-1));//default forward is -z
     viewVec.normalize();
 
     float roll;
-    cam->rot.getEulerAngles(&pitch,&yaw,&roll);
+    cam->getLocalRot().getEulerAngles(&pitch,&yaw,&roll);
 
     this->updateCameraRot();
 }
@@ -125,8 +125,8 @@ void EditorCameraController::onMouseMove(int x,int y)
     {
         //translate camera
         float dragSpeed = 0.01f;
-        auto dir = camera->rot.rotatedVector(QVector3D(x*dragSpeed,-y*dragSpeed,0));
-        camera->pos += dir;
+        auto dir = camera->getLocalRot().rotatedVector(QVector3D(x*dragSpeed,-y*dragSpeed,0));
+        camera->setLocalPos( camera->getLocalPos() + dir);
 
         camera->update(0);//force calculation of global transform. find a better way to do this
     }
@@ -149,8 +149,9 @@ void EditorCameraController::onMouseMove(int x,int y)
 void EditorCameraController::onMouseWheel(int delta)
 {
     auto zoomSpeed = 0.01f;
-    auto forward = camera->rot.rotatedVector(QVector3D(0,0,-1));
-    camera->pos += forward*zoomSpeed*delta;
+    auto forward = camera->getLocalRot().rotatedVector(QVector3D(0,0,-1));
+    auto movement = camera->getLocalPos() + forward*zoomSpeed*delta;
+    camera->setLocalPos(movement);
 }
 
 /**
@@ -162,30 +163,33 @@ void EditorCameraController::updateCameraRot()
     //QQuaternion pitchQuat = QQuaternion::fromEulerAngles(pitch,0,0);
 
     //camera->rot = yawQuat*pitchQuat;
-    camera->rot = QQuaternion::fromEulerAngles(pitch,yaw,0);
+    camera->setLocalRot(QQuaternion::fromEulerAngles(pitch,yaw,0));
     camera->update(0);
 }
 
 void EditorCameraController::update(float dt)
 {
     const QVector3D upVector(0, 1, 0);
-    auto forwardVector = camera->rot.rotatedVector(QVector3D(0, 0, -1));
+    auto forwardVector = camera->getLocalRot().rotatedVector(QVector3D(0, 0, -1));
     auto x = QVector3D::crossProduct(forwardVector,upVector).normalized();
     auto z = QVector3D::crossProduct(upVector,x).normalized();
 
+    auto camPos = camera->getLocalPos();
     // left
     if(KeyboardState::isKeyDown(Qt::Key_Left) ||KeyboardState::isKeyDown(Qt::Key_A) )
-        camera->pos -= x * linearSpeed;
+        camPos -= x * linearSpeed;
 
     // right
     if(KeyboardState::isKeyDown(Qt::Key_Right) ||KeyboardState::isKeyDown(Qt::Key_D) )
-        camera->pos += x * linearSpeed;
+        camPos += x * linearSpeed;
 
     // up
     if(KeyboardState::isKeyDown(Qt::Key_Up) ||KeyboardState::isKeyDown(Qt::Key_W) )
-        camera->pos += z * linearSpeed;
+        camPos += z * linearSpeed;
 
     // down
     if(KeyboardState::isKeyDown(Qt::Key_Down) ||KeyboardState::isKeyDown(Qt::Key_S) )
-        camera->pos -= z * linearSpeed;
+        camPos -= z * linearSpeed;
+
+    camera->setLocalPos(camPos);
 }

--- a/src/editor/editorvrcontroller.cpp
+++ b/src/editor/editorvrcontroller.cpp
@@ -82,36 +82,40 @@ void EditorVrController::update(float dt)
     auto x = QVector3D::crossProduct(forwardVector,upVector).normalized();
     auto z = QVector3D::crossProduct(upVector,x).normalized();
 
+    auto camPos = camera->getLocalPos();
     // left
     if(KeyboardState::isKeyDown(Qt::Key_Left) ||KeyboardState::isKeyDown(Qt::Key_A) )
-        camera->pos -= x * linearSpeed;
+        camPos -= x * linearSpeed;
 
     // right
     if(KeyboardState::isKeyDown(Qt::Key_Right) ||KeyboardState::isKeyDown(Qt::Key_D) )
-        camera->pos += x * linearSpeed;
+        camPos += x * linearSpeed;
 
     // up
     if(KeyboardState::isKeyDown(Qt::Key_Up) ||KeyboardState::isKeyDown(Qt::Key_W) )
-        camera->pos += z * linearSpeed;
+        camPos += z * linearSpeed;
 
     // down
     if(KeyboardState::isKeyDown(Qt::Key_Down) ||KeyboardState::isKeyDown(Qt::Key_S) )
-        camera->pos -= z * linearSpeed;
+        camPos -= z * linearSpeed;
+
+    camera->setLocalPos(camPos);
 
     // touch controls
     auto leftTouch = vrDevice->getTouchController(0);
     if (leftTouch->isTracking()) {
         auto dir = leftTouch->GetThumbstick();
-        camera->pos += x * linearSpeed * dir.x() * 2;
-        camera->pos += z * linearSpeed * dir.y() * 2;
+        camPos += x * linearSpeed * dir.x() * 2;
+        camPos += z * linearSpeed * dir.y() * 2;
 
 
         if(leftTouch->isButtonDown(iris::VrTouchInput::Y))
-            camera->pos += QVector3D(0, linearSpeed, 0);
+            camPos += QVector3D(0, linearSpeed, 0);
         if(leftTouch->isButtonDown(iris::VrTouchInput::X))
-            camera->pos += QVector3D(0, -linearSpeed, 0);
+            camPos += QVector3D(0, -linearSpeed, 0);
 
-        camera->rot = QQuaternion();
+        camera->setLocalPos(camPos);
+        camera->setLocalRot(QQuaternion());
         camera->update(0);
 
 
@@ -173,12 +177,19 @@ void EditorVrController::update(float dt)
             // calculate position relative to parent
             auto localTransform = leftPickedNode->parent->getGlobalTransform().inverted() * nodeGlobal;
 
+            QVector3D pos, scale;
+            QQuaternion rot;
             // decompose matrix to assign pos, rot and scale
             iris::MathHelper::decomposeMatrix(localTransform,
-                                              leftPickedNode->pos,
-                                              leftPickedNode->rot,
-                                              leftPickedNode->scale);
-            leftPickedNode->rot.normalize();
+                                              pos,
+                                              rot,
+                                              scale);
+
+            leftPickedNode->setLocalPos(pos);
+            rot.normalize();
+            leftPickedNode->setLocalRot(rot);
+            leftPickedNode->setLocalScale(scale);
+
 
             // @todo: force recalculatioin of global transform
             // leftPickedNode->update(0);// bad!

--- a/src/editor/editorvrcontroller.h
+++ b/src/editor/editorvrcontroller.h
@@ -19,13 +19,13 @@ For more information see the LICENSE file
 class EditorVrController : public CameraControllerBase
 {
 public:
-    iris::Mesh* leftHandMesh;
-    iris::Mesh* rightHandMesh;
+    iris::MeshPtr leftHandMesh;
+    iris::MeshPtr rightHandMesh;
 
     iris::RenderItem* leftHandRenderItem;
     iris::RenderItem* rightHandRenderItem;
 
-    iris::Mesh* beamMesh;
+    iris::MeshPtr beamMesh;
     iris::RenderItem* leftBeamRenderItem;
     iris::RenderItem* rightBeamRenderItem;
 
@@ -44,8 +44,8 @@ public:
 
     EditorVrController();
 
-    void setScene(iris::ScenePtr scene)
-;
+    void setScene(iris::ScenePtr scene);
+
     void updateCameraRot();
 
     void update(float dt);

--- a/src/editor/gizmohandle.h
+++ b/src/editor/gizmohandle.h
@@ -83,7 +83,8 @@ public:
     }
 
     void setHandlePosition(const QVector3D& position) {
-         gizmoHandle->pos = this->handlePosition = position;
+        this->handlePosition = position;
+        gizmoHandle->setLocalPos(position);
     }
 
     QVector3D getHandlePosition() const {
@@ -99,7 +100,8 @@ public:
     }
 
     void setHandleRotation(const QVector3D& rotation) {
-        gizmoHandle->rot = this->handleRotation = QQuaternion::fromEulerAngles(rotation);
+        this->handleRotation = QQuaternion::fromEulerAngles(rotation);
+        gizmoHandle->setLocalRot(this->handleRotation);
     }
 
     QQuaternion getHandleRotation() const {

--- a/src/editor/orbitalcameracontroller.cpp
+++ b/src/editor/orbitalcameracontroller.cpp
@@ -38,11 +38,11 @@ void OrbitalCameraController::setCamera(QSharedPointer<iris::CameraNode>  cam)
     this->camera = cam;
 
     //calculate the location of the pivot
-    auto viewVec = cam->rot.rotatedVector(QVector3D(0,0,-1));//default forward is -z
-    pivot = cam->pos + (viewVec*distFromPivot);
+    auto viewVec = cam->getLocalRot().rotatedVector(QVector3D(0,0,-1));//default forward is -z
+    pivot = cam->getLocalPos() + (viewVec*distFromPivot);
 
     float roll;
-    cam->rot.getEulerAngles(&pitch,&yaw,&roll);
+    cam->getLocalRot().getEulerAngles(&pitch,&yaw,&roll);
 
     this->updateCameraRot();
 }
@@ -60,7 +60,7 @@ void OrbitalCameraController::onMouseMove(int x,int y)
     {
         //translate camera
         float dragSpeed = 0.01f;
-        auto dir = camera->rot.rotatedVector(QVector3D(x*dragSpeed,-y*dragSpeed,0));
+        auto dir = camera->getLocalRot().rotatedVector(QVector3D(x*dragSpeed,-y*dragSpeed,0));
         pivot += dir;
     }
 
@@ -89,8 +89,8 @@ void OrbitalCameraController::updateCameraRot()
     auto rot = QQuaternion::fromEulerAngles(pitch,yaw,0);
     auto localPos = rot.rotatedVector(QVector3D(0,0,1));
 
-    camera->pos = pivot+(localPos*distFromPivot);
-    camera->rot = rot;
+    camera->setLocalPos(pivot+(localPos*distFromPivot));
+    camera->setLocalRot(rot);
     camera->update(0);
 
 

--- a/src/editor/scalegizmo.h
+++ b/src/editor/scalegizmo.h
@@ -68,11 +68,11 @@ public:
     }
 
     void updateTransforms(const QVector3D& pos) {
-        scale = gizmoSize * ((pos - lastSelectedNode->pos).length() / qTan(45.0f / 2.0f));
+        scale = gizmoSize * ((pos - lastSelectedNode->getLocalPos()).length() / qTan(45.0f / 2.0f));
 
         for (int i = 0; i < 3; i++) {
-            handles[i]->gizmoHandle->pos = lastSelectedNode->getGlobalPosition();
-            handles[i]->gizmoHandle->scale = QVector3D(scale, scale, scale);
+            handles[i]->gizmoHandle->setLocalPos(lastSelectedNode->getGlobalPosition());
+            handles[i]->gizmoHandle->setLocalScale(QVector3D(scale, scale, scale));
         }
     }
 
@@ -96,7 +96,7 @@ public:
                 Offset = QVector3D(0, 0, Offset.z());
             }
 
-            lastSelectedNode->scale += Offset;
+            lastSelectedNode->setLocalScale( lastSelectedNode->getLocalScale() + Offset);
 
             finalHitPoint = Point;
         }
@@ -138,13 +138,13 @@ public:
             widgetPos.translate(this->currentNode->getGlobalPosition());
             widgetPos.scale(scale);
             for (int i = 0; i < 3; i++) {
-                handles[i]->gizmoHandle->pos = this->currentNode->getGlobalPosition();
+                handles[i]->gizmoHandle->setLocalPos(this->currentNode->getGlobalPosition());
             }
         } else if (!!this->lastSelectedNode) {
             widgetPos.translate(this->lastSelectedNode->getGlobalPosition());
             widgetPos.scale(scale);
             for (int i = 0; i < 3; i++) {
-                handles[i]->gizmoHandle->pos = this->lastSelectedNode->getGlobalPosition();
+                handles[i]->gizmoHandle->setLocalPos(this->lastSelectedNode->getGlobalPosition());
             }
         }
 
@@ -207,7 +207,7 @@ public:
     void isGizmoHit(const iris::CameraNodePtr& camera, const QPointF& pos, const QVector3D& rayDir) {
         camera->updateCameraMatrices();
 
-        auto segStart = camera->pos;
+        auto segStart = camera->getLocalPos();
         auto segEnd = segStart + rayDir * 1024;
 
         QList<PickingResult> hitList;

--- a/src/editor/translationgizmo.h
+++ b/src/editor/translationgizmo.h
@@ -77,16 +77,16 @@ public:
     }
 
     void updateTransforms(const QVector3D& pos) {
-        scale = gizmoSize * ((pos - lastSelectedNode->pos).length() / qTan(45.0f / 2.0f));
+        scale = gizmoSize * ((pos - lastSelectedNode->getLocalPos()).length() / qTan(45.0f / 2.0f));
 
         for (int i = 0; i < 3; i++) {
-            handles[i]->gizmoHandle->pos = lastSelectedNode->getGlobalPosition();
+            handles[i]->gizmoHandle->setLocalPos(lastSelectedNode->getGlobalPosition());
 //            if (transformOrientation == "Local") {
 //                handles[i]->gizmoHandle->rot = lastSelectedNode->rot;
 //            } else {
 //                handles[i]->gizmoHandle->rot = QQuaternion();
 //            }
-            handles[i]->gizmoHandle->scale = QVector3D(scale, scale, scale);
+            handles[i]->gizmoHandle->setLocalScale(QVector3D(scale, scale, scale));
         }
     }
 
@@ -110,8 +110,8 @@ public:
                 Offset = QVector3D(0, 0, Offset.z());
             }
 
-            currentNode->pos += Offset;
-            lastSelectedNode->pos += Offset;
+            currentNode->setLocalPos( currentNode->getLocalPos() + Offset);
+            lastSelectedNode->setLocalPos( lastSelectedNode->getLocalPos() + Offset);
 
             finalHitPoint = Point;
         }
@@ -143,11 +143,11 @@ public:
 
         if (!!this->currentNode) {
             for (int i = 0; i < 3; i++) {
-                handles[i]->gizmoHandle->pos = currentNode->pos;
+                handles[i]->gizmoHandle->setLocalPos(currentNode->getLocalPos());
             }
         } else {
             for (int i = 0; i < 3; i++) {
-                handles[i]->gizmoHandle->pos = lastSelectedNode->getGlobalPosition();
+                handles[i]->gizmoHandle->setLocalPos(lastSelectedNode->getGlobalPosition());
             }
         }
 
@@ -160,7 +160,7 @@ public:
             QMatrix4x4 widgetPos;
             widgetPos.setToIdentity();
 
-            widgetPos.translate(handles[i]->gizmoHandle->pos);
+            widgetPos.translate(handles[i]->gizmoHandle->getLocalPos());
 //            widgetPos.rotate(handles[i]->gizmoHandle->rot);
             widgetPos.scale(scale);
 
@@ -217,7 +217,7 @@ public:
     void isGizmoHit(const iris::CameraNodePtr& camera, const QPointF& pos, const QVector3D& rayDir) {
         camera->updateCameraMatrices();
 
-        auto segStart = camera->pos;
+        auto segStart = camera->getLocalPos();
         auto segEnd = segStart + rayDir * 1024;
 
         QList<PickingResult> hitList;

--- a/src/io/scenereader.cpp
+++ b/src/io/scenereader.cpp
@@ -560,7 +560,7 @@ void SceneReader::extractAssetsFromAssimpScene(QString filePath)
     if (!assimpScenes.contains(filePath)) {
 //        auto meshList = iris::GraphicsHelper::loadAllMeshesFromFile(filePath);
 //        auto anims = iris::Mesh::extractAnimations(scene, filePath);
-        QList<iris::Mesh*> meshList;
+        QList<iris::MeshPtr> meshList;
         QMap<QString, iris::SkeletalAnimationPtr> anims;
         iris::GraphicsHelper::loadAllMeshesAndAnimationsFromFile(filePath, meshList, anims);
 
@@ -577,7 +577,7 @@ void SceneReader::extractAssetsFromAssimpScene(QString filePath)
  * @param index
  * @return
  */
-iris::Mesh* SceneReader::getMesh(QString filePath, int index)
+iris::MeshPtr SceneReader::getMesh(QString filePath, int index)
 {
     extractAssetsFromAssimpScene(filePath);
 
@@ -586,7 +586,7 @@ iris::Mesh* SceneReader::getMesh(QString filePath, int index)
     if (index < meshList.size()) return meshList[index];
 
     // maybe the mesh was modified after the file was saved
-    return nullptr;
+    return iris::MeshPtr();
 }
 
 iris::SkeletalAnimationPtr SceneReader::getSkeletalAnimation(QString filePath, QString animName)

--- a/src/io/scenereader.cpp
+++ b/src/io/scenereader.cpp
@@ -108,8 +108,8 @@ EditorData* SceneReader::readEditorData(QJsonObject& projectObj)
     camera->angle = (float)camObj["angle"].toDouble(45.f);
     camera->nearClip = (float)camObj["nearClip"].toDouble(1.f);
     camera->farClip = (float)camObj["farClip"].toDouble(100.f);
-    camera->pos = readVector3(camObj["pos"].toObject());
-    camera->rot = QQuaternion::fromEulerAngles(readVector3(camObj["rot"].toObject()));
+    camera->setLocalPos(readVector3(camObj["pos"].toObject()));
+    camera->setLocalRot(QQuaternion::fromEulerAngles(readVector3(camObj["rot"].toObject())));
 
     auto editorData = new EditorData();
     editorData->editorCamera = camera;
@@ -359,24 +359,24 @@ void SceneReader::readSceneNodeTransform(QJsonObject& nodeObj,iris::SceneNodePtr
     auto pos = nodeObj["pos"].toObject();
     if(!pos.isEmpty())
     {
-        sceneNode->pos = readVector3(pos);
+        sceneNode->setLocalPos(readVector3(pos));
     }
 
     auto rot = nodeObj["rot"].toObject();
     if(!rot.isEmpty())
     {
         //the rotation is stored as euler angles
-        sceneNode->rot = QQuaternion::fromEulerAngles(readVector3(rot));
+        sceneNode->setLocalRot(QQuaternion::fromEulerAngles(readVector3(rot)));
     }
 
     auto scale = nodeObj["scale"].toObject();
     if(!scale.isEmpty())
     {
-        sceneNode->scale = readVector3(scale);
+        sceneNode->setLocalScale(readVector3(scale));
     }
     else
     {
-        sceneNode->scale = QVector3D(1,1,1);
+        sceneNode->setLocalScale(QVector3D(1,1,1));
     }
 }
 

--- a/src/io/scenereader.h
+++ b/src/io/scenereader.h
@@ -32,7 +32,7 @@ class aiScene;
 
 class SceneReader : public AssetIOBase
 {
-    QHash<QString,QList<iris::Mesh*>> meshes;
+    QHash<QString,QList<iris::MeshPtr>> meshes;
     QSet<QString> assimpScenes;
     QHash<QString,QMap<QString, iris::SkeletalAnimationPtr>> animations;
 
@@ -106,7 +106,7 @@ public:
      * @param index
      * @return
      */
-    iris::Mesh* getMesh(QString filePath, int index);
+    iris::MeshPtr getMesh(QString filePath, int index);
 
     iris::SkeletalAnimationPtr getSkeletalAnimation(QString filePath, QString animName);
 };

--- a/src/io/scenewriter.cpp
+++ b/src/io/scenewriter.cpp
@@ -160,8 +160,8 @@ void SceneWriter::writeEditorData(QJsonObject& projectObj,EditorData* editorData
     cameraObj["angle"] = cam->angle;
     cameraObj["nearClip"] = cam->nearClip;
     cameraObj["farClip"] = cam->farClip;
-    cameraObj["pos"] = jsonVector3(editorData->editorCamera->pos);
-    cameraObj["rot"] = jsonVector3(editorData->editorCamera->rot.toEulerAngles());
+    cameraObj["pos"] = jsonVector3(editorData->editorCamera->getLocalPos());
+    cameraObj["rot"] = jsonVector3(editorData->editorCamera->getLocalRot().toEulerAngles());
 
     editorObj["camera"] = cameraObj;
     projectObj["editor"] = editorObj;
@@ -173,10 +173,10 @@ void SceneWriter::writeSceneNode(QJsonObject& sceneNodeObj,iris::SceneNodePtr sc
     sceneNodeObj["attached"] = sceneNode->isAttached();
     sceneNodeObj["type"] = getSceneNodeTypeName(sceneNode->sceneNodeType);
 
-    sceneNodeObj["pos"] = jsonVector3(sceneNode->pos);
-    auto rot = sceneNode->rot.toEulerAngles();
+    sceneNodeObj["pos"] = jsonVector3(sceneNode->getLocalPos());
+    auto rot = sceneNode->getLocalRot().toEulerAngles();
     sceneNodeObj["rot"] = jsonVector3(rot);
-    sceneNodeObj["scale"] = jsonVector3(sceneNode->scale);
+    sceneNodeObj["scale"] = jsonVector3(sceneNode->getLocalScale());
 
 
     //todo: write data specific to node type

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -69,7 +69,8 @@ HEADERS += \
     $$PWD/src/animation/floatcurve.h \
     $$PWD/src/scenegraph/scene.h \
     $$PWD/src/scenegraph/scenenode.h \
-    $$PWD/src/core/property.h
+    $$PWD/src/core/property.h \
+    $$PWD/src/geometry/boundingsphere.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -70,7 +70,9 @@ HEADERS += \
     $$PWD/src/scenegraph/scene.h \
     $$PWD/src/scenegraph/scenenode.h \
     $$PWD/src/core/property.h \
-    $$PWD/src/geometry/boundingsphere.h
+    $$PWD/src/geometry/boundingsphere.h \
+    $$PWD/src/geometry/plane.h \
+    $$PWD/src/geometry/frustum.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -113,7 +115,9 @@ SOURCES += \
     $$PWD/src/animation/skeletalanimation.cpp \
     $$PWD/src/graphics/skeleton.cpp \
     $$PWD/src/scenegraph/scene.cpp \
-    $$PWD/src/scenegraph/scenenode.cpp
+    $$PWD/src/scenegraph/scenenode.cpp \
+    $$PWD/src/geometry/plane.cpp \
+    $$PWD/src/geometry/frustum.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/src/geometry/boundingsphere.h
+++ b/src/irisgl/src/geometry/boundingsphere.h
@@ -1,0 +1,30 @@
+#ifndef BOUNDINGSPHERE_H
+#define BOUNDINGSPHERE_H
+
+#include <QVector3D>
+
+namespace iris
+{
+
+class BoundingSphere
+{
+public:
+    QVector3D pos;
+    float radius;
+
+    void expand(QVector3D point)
+    {
+        auto dist = pos.distanceToPoint(point);
+        if (dist > radius)
+            radius =dist;
+    }
+
+    bool intersects(BoundingSphere* other)
+    {
+        return pos.distanceToPoint(other->pos) < radius + other->radius;
+    }
+};
+
+}
+
+#endif // BOUNDINGSPHERE_H

--- a/src/irisgl/src/geometry/frustum.cpp
+++ b/src/irisgl/src/geometry/frustum.cpp
@@ -1,0 +1,50 @@
+#include "frustum.h"
+#include "plane.h"
+#include "boundingsphere.h"
+
+namespace iris {
+
+// https://github.com/playcanvas/engine/blob/master/src/shape/frustum.js#L27
+void Frustum::build(QMatrix4x4 viewProj)
+{
+    planes.clear();
+
+    // left
+    auto plane = viewProj.row(3) + viewProj.row(0);
+    planes.append(Plane(plane.toVector3D().normalized(), plane.w()/plane.toVector3D().length()));
+
+    // right
+    plane = viewProj.row(3) - viewProj.row(0);
+    planes.append(Plane(plane.toVector3D().normalized(), plane.w()/plane.toVector3D().length()));
+
+    // top
+    plane = viewProj.row(3) + viewProj.row(1);
+    planes.append(Plane(plane.toVector3D().normalized(), plane.w()/plane.toVector3D().length()));
+
+    // bottom
+    plane = viewProj.row(3) - viewProj.row(1);
+    planes.append(Plane(plane.toVector3D().normalized(), plane.w()/plane.toVector3D().length()));
+
+    // front
+    plane = viewProj.row(3) + viewProj.row(2);
+    planes.append(Plane(plane.toVector3D().normalized(), plane.w()/plane.toVector3D().length()));
+
+    // back
+    plane = viewProj.row(3) - viewProj.row(2);
+    planes.append(Plane(plane.toVector3D().normalized(), plane.w()/plane.toVector3D().length()));
+
+}
+
+bool Frustum::isSphereInside(BoundingSphere *sphere)
+{
+    for(auto& plane : planes) {
+        if (plane.classifySphere(sphere) == SphereClassification::Behind)
+            return false;
+    }
+
+    return true;
+}
+
+
+
+}

--- a/src/irisgl/src/geometry/frustum.cpp
+++ b/src/irisgl/src/geometry/frustum.cpp
@@ -1,6 +1,7 @@
 #include "frustum.h"
 #include "plane.h"
 #include "boundingsphere.h"
+#include <QMatrix4x4>
 
 namespace iris {
 

--- a/src/irisgl/src/geometry/frustum.h
+++ b/src/irisgl/src/geometry/frustum.h
@@ -1,6 +1,8 @@
 #ifndef FRUSTUM_H
 #define FRUSTUM_H
 
+#include <QList>
+#include <QMatrix4x4>
 #include "plane.h"
 
 namespace iris {

--- a/src/irisgl/src/geometry/frustum.h
+++ b/src/irisgl/src/geometry/frustum.h
@@ -1,0 +1,23 @@
+#ifndef FRUSTUM_H
+#define FRUSTUM_H
+
+#include "plane.h"
+
+namespace iris {
+
+class BoundingSphere;
+class Frustum
+{
+public:
+    QList<Plane> planes;
+
+    // projection x view
+    void build(QMatrix4x4 viewProj);
+
+    // checks if the sphere is inside or touches the bounding sphere
+    bool isSphereInside(BoundingSphere* sphere);
+};
+
+}
+
+#endif // FRUSTUM_H

--- a/src/irisgl/src/geometry/plane.cpp
+++ b/src/irisgl/src/geometry/plane.cpp
@@ -1,0 +1,33 @@
+#include "plane.h"
+#include "boundingsphere.h"
+
+
+namespace iris {
+
+SphereClassification Plane::classifySphere(BoundingSphere *sphere)
+{
+    auto& spherePos = sphere->pos;
+
+    auto dist = normal.x() * spherePos.x() +
+                normal.y() * spherePos.y() +
+                normal.z() * spherePos.z() +
+                d;
+
+    if (dist < -sphere->radius)
+        return SphereClassification::Behind;
+    if (dist > sphere->radius)
+        return SphereClassification::InFront;
+
+    return SphereClassification::Intersects;
+
+}
+
+Plane::Plane(QVector3D planeNormal, float distance)
+{
+    normal = planeNormal;
+    d = distance;
+}
+
+
+
+}

--- a/src/irisgl/src/geometry/plane.cpp
+++ b/src/irisgl/src/geometry/plane.cpp
@@ -22,6 +22,12 @@ SphereClassification Plane::classifySphere(BoundingSphere *sphere)
 
 }
 
+Plane::Plane()
+{
+    normal = QVector3D(0, 1, 0);
+    d = 0;
+}
+
 Plane::Plane(QVector3D planeNormal, float distance)
 {
     normal = planeNormal;

--- a/src/irisgl/src/geometry/plane.h
+++ b/src/irisgl/src/geometry/plane.h
@@ -21,6 +21,7 @@ public:
     QVector3D normal;
     float d;
 
+    Plane();
     Plane(QVector3D planeNormal, float distance);
 
     SphereClassification classifySphere(BoundingSphere* sphere);

--- a/src/irisgl/src/geometry/plane.h
+++ b/src/irisgl/src/geometry/plane.h
@@ -1,0 +1,31 @@
+#ifndef PLANE_H
+#define PLANE_H
+
+#include <QVector3D>
+#include <QVector4D>
+
+namespace iris
+{
+class BoundingSphere;
+
+enum SphereClassification
+{
+    InFront,
+    Intersects,
+    Behind
+};
+
+class Plane
+{
+public:
+    QVector3D normal;
+    float d;
+
+    Plane(QVector3D planeNormal, float distance);
+
+    SphereClassification classifySphere(BoundingSphere* sphere);
+};
+
+}
+
+#endif // PLANE_H

--- a/src/irisgl/src/graphics/graphicshelper.cpp
+++ b/src/irisgl/src/graphics/graphicshelper.cpp
@@ -97,7 +97,7 @@ QString GraphicsHelper::loadAndProcessShader(QString shaderPath)
     return lines.join('\n');
 }
 
-QList<iris::Mesh*> GraphicsHelper::loadAllMeshesFromFile(QString filePath)
+QList<iris::MeshPtr> GraphicsHelper::loadAllMeshesFromFile(QString filePath)
 {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(filePath.toStdString().c_str(), aiProcessPreset_TargetRealtime_Fast);
@@ -105,7 +105,7 @@ QList<iris::Mesh*> GraphicsHelper::loadAllMeshesFromFile(QString filePath)
     return loadAllMeshesFromAssimpScene(scene);
 }
 
-void GraphicsHelper::loadAllMeshesAndAnimationsFromFile(QString filePath, QList<Mesh *> &meshes, QMap<QString, SkeletalAnimationPtr> &animations)
+void GraphicsHelper::loadAllMeshesAndAnimationsFromFile(QString filePath, QList<MeshPtr> &meshes, QMap<QString, SkeletalAnimationPtr> &animations)
 {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(filePath.toStdString().c_str(), aiProcessPreset_TargetRealtime_Fast);
@@ -116,16 +116,16 @@ void GraphicsHelper::loadAllMeshesAndAnimationsFromFile(QString filePath, QList<
     }
 }
 
-QList<Mesh *> GraphicsHelper::loadAllMeshesFromAssimpScene(const aiScene *scene)
+QList<MeshPtr> GraphicsHelper::loadAllMeshesFromAssimpScene(const aiScene *scene)
 {
-    QList<Mesh*> meshes;
+    QList<MeshPtr> meshes;
 
     if(scene)
     {
         for(unsigned i = 0; i < scene->mNumMeshes; i++)
         {
             auto m = scene->mMeshes[i];
-            auto mesh = new Mesh(m);
+            auto mesh = iris::MeshPtr(new Mesh(m));
             if (m->HasBones()) {
                 auto skel = Mesh::extractSkeleton(m, scene);
                 mesh->setSkeleton(skel);

--- a/src/irisgl/src/graphics/graphicshelper.h
+++ b/src/irisgl/src/graphics/graphicshelper.h
@@ -36,11 +36,11 @@ public:
      * @param filePath
      * @return
      */
-    static QList<Mesh*> loadAllMeshesFromFile(QString filePath);
+    static QList<MeshPtr> loadAllMeshesFromFile(QString filePath);
 
-    static void loadAllMeshesAndAnimationsFromFile(QString filePath, QList<Mesh*>& meshes, QMap<QString, SkeletalAnimationPtr>& animations);
+    static void loadAllMeshesAndAnimationsFromFile(QString filePath, QList<MeshPtr>& meshes, QMap<QString, SkeletalAnimationPtr>& animations);
 
-    static QList<Mesh*> loadAllMeshesFromAssimpScene(const aiScene* scene);
+    static QList<MeshPtr> loadAllMeshesFromAssimpScene(const aiScene* scene);
 };
 
 }

--- a/src/irisgl/src/graphics/mesh.cpp
+++ b/src/irisgl/src/graphics/mesh.cpp
@@ -27,6 +27,7 @@ For more information see the LICENSE file
 #include "../geometry/trimesh.h"
 #include "skeleton.h"
 #include "../animation/skeletalanimation.h"
+#include "../geometry/boundingsphere.h"
 
 #include <functional>
 
@@ -63,6 +64,8 @@ Mesh::Mesh(aiMesh* mesh)
     numFaces = mesh->mNumFaces;
 
     gl->glGenVertexArrays(1,&vao);
+
+    boundingSphere = new BoundingSphere();
 
     if(!mesh->HasPositions())
         return;
@@ -148,6 +151,11 @@ Mesh::Mesh(aiMesh* mesh)
         triMesh->addTriangle(QVector3D(a.x, a.y, a.z),
                              QVector3D(b.x, b.y, b.z),
                              QVector3D(c.x, c.y, c.z));
+
+        // redundant, but good enough for now
+        boundingSphere->expand(a);
+        boundingSphere->expand(b);
+        boundingSphere->expand(c);
     }
 
     gl->glGenBuffers(1, &indexBuffer);

--- a/src/irisgl/src/graphics/mesh.cpp
+++ b/src/irisgl/src/graphics/mesh.cpp
@@ -153,9 +153,9 @@ Mesh::Mesh(aiMesh* mesh)
                              QVector3D(c.x, c.y, c.z));
 
         // redundant, but good enough for now
-        boundingSphere->expand(a);
-        boundingSphere->expand(b);
-        boundingSphere->expand(c);
+        boundingSphere->expand(QVector3D(a.x, a.y, a.z));
+        boundingSphere->expand(QVector3D(b.x, b.y, b.z));
+        boundingSphere->expand(QVector3D(c.x, c.y, c.z));
     }
 
     gl->glGenBuffers(1, &indexBuffer);

--- a/src/irisgl/src/graphics/mesh.cpp
+++ b/src/irisgl/src/graphics/mesh.cpp
@@ -9,6 +9,7 @@ and/or modify it under the terms of the GPLv3 License
 For more information see the LICENSE file
 *************************************************************************/
 
+#include "../irisglfwd.h"
 #include "mesh.h"
 #include "material.h"
 
@@ -251,7 +252,7 @@ void Mesh::draw(QOpenGLFunctions_3_2_Core* gl,QOpenGLShaderProgram* program,GLen
     gl->glBindVertexArray(0);
 }
 
-Mesh* Mesh::loadMesh(QString filePath)
+MeshPtr Mesh::loadMesh(QString filePath)
 {
     Assimp::Importer importer;
     const aiScene *scene;
@@ -282,10 +283,10 @@ Mesh* Mesh::loadMesh(QString filePath)
         meshObj->addSkeletalAnimation(animName, anims[animName]);
     }
 
-    return meshObj;
+    return MeshPtr(meshObj);
 }
 
-Mesh *Mesh::loadAnimatedMesh(QString filePath)
+MeshPtr Mesh::loadAnimatedMesh(QString filePath)
 {
     Assimp::Importer importer;
     const aiScene *scene;
@@ -306,7 +307,7 @@ Mesh *Mesh::loadAnimatedMesh(QString filePath)
     //extract animations from scene
     auto mesh = new Mesh(scene->mMeshes[0]);
 
-    return mesh;
+    return MeshPtr(mesh);
 }
 
 SkeletonPtr Mesh::extractSkeleton(const aiMesh *mesh, const aiScene *scene)

--- a/src/irisgl/src/graphics/mesh.h
+++ b/src/irisgl/src/graphics/mesh.h
@@ -18,12 +18,13 @@ For more information see the LICENSE file
 #include "../irisglfwd.h"
 #include "../animation/skeletalanimation.h"
 
+
 class aiMesh;
 class aiScene;
 class QOpenGLBuffer;
 class QOpenGLFunctions_3_2_Core;
 class QOpenGLShaderProgram;
-
+class BoundingSphere;
 
 namespace iris
 {
@@ -82,6 +83,8 @@ public:
     GLuint vao;
     GLuint indexBuffer;
     bool usesIndexBuffer;
+
+    BoundingSphere* boundingSphere;
 
     // will cause problems if a shader was freed and gl gives the
     // id to another shader

--- a/src/irisgl/src/graphics/mesh.h
+++ b/src/irisgl/src/graphics/mesh.h
@@ -117,8 +117,8 @@ public:
     void draw(QOpenGLFunctions_3_2_Core* gl, Material* mat, GLenum primitiveMode = GL_TRIANGLES);
     void draw(QOpenGLFunctions_3_2_Core* gl, QOpenGLShaderProgram* mat, GLenum primitiveMode = GL_TRIANGLES);
 
-    static Mesh* loadMesh(QString filePath);
-    static Mesh* loadAnimatedMesh(QString filePath);
+    static MeshPtr loadMesh(QString filePath);
+    static MeshPtr loadAnimatedMesh(QString filePath);
     static SkeletonPtr extractSkeleton(const aiMesh* mesh, const aiScene* scene);
     static QMap<QString, SkeletalAnimationPtr> extractAnimations(const aiScene* scene, QString source = "");
 
@@ -145,7 +145,7 @@ private:
     void addIndexArray(void* data,int size,GLenum type);
 };
 
-typedef QSharedPointer<Mesh> MeshPtr;
+//typedef QSharedPointer<Mesh> MeshPtr;
 
 }
 

--- a/src/irisgl/src/graphics/mesh.h
+++ b/src/irisgl/src/graphics/mesh.h
@@ -24,10 +24,12 @@ class aiScene;
 class QOpenGLBuffer;
 class QOpenGLFunctions_3_2_Core;
 class QOpenGLShaderProgram;
-class BoundingSphere;
+
 
 namespace iris
 {
+
+class BoundingSphere;
 
 enum class VertexAttribUsage : int
 {

--- a/src/irisgl/src/graphics/renderdata.h
+++ b/src/irisgl/src/graphics/renderdata.h
@@ -13,6 +13,7 @@ For more information see the LICENSE file
 #define RENDERDATA_H
 
 #include "../irisglfwd.h"
+#include "../geometry/frustum.h"
 #include <QColor>
 
 namespace iris
@@ -23,6 +24,7 @@ struct RenderData
     ScenePtr scene;
     MaterialPtr material;
 
+    iris::Frustum frustum;
     QMatrix4x4 viewMatrix;
     QMatrix4x4 projMatrix;
 

--- a/src/irisgl/src/graphics/renderitem.h
+++ b/src/irisgl/src/graphics/renderitem.h
@@ -13,6 +13,7 @@ For more information see the LICENSE file
 #define RENDERITEM_H
 
 #include "../irisglfwd.h"
+#include "../geometry/boundingsphere.h"
 #include <QMatrix4x4>
 
 class QOpenGLShaderProgram;
@@ -83,6 +84,9 @@ struct RenderItem
 
     //states
     RenderStates renderStates;
+
+    bool cullable = false;
+    BoundingSphere boundingSphere;
 
     //sort order for render layer
     //used if no material is specified

--- a/src/irisgl/src/graphics/renderitem.h
+++ b/src/irisgl/src/graphics/renderitem.h
@@ -74,7 +74,7 @@ struct RenderItem
 {
     RenderItemType type;
     MaterialPtr material;
-    Mesh* mesh;
+    MeshPtr mesh;
 
     QMatrix4x4 worldMatrix;
     SceneNodePtr sceneNode;

--- a/src/irisgl/src/irisglfwd.h
+++ b/src/irisgl/src/irisglfwd.h
@@ -72,6 +72,7 @@ typedef QSharedPointer<iris::Animation> AnimationPtr;
 typedef QSharedPointer<Shader> ShaderPtr;
 typedef QSharedPointer<Scene> ScenePtr;
 typedef QSharedPointer<SceneNode> SceneNodePtr;
+typedef QSharedPointer<Mesh> MeshPtr;
 typedef QSharedPointer<Material> MaterialPtr;
 typedef QSharedPointer<DefaultMaterial> DefaultMaterialPtr;
 typedef QSharedPointer<LightNode> LightNodePtr;

--- a/src/irisgl/src/irisglfwd.h
+++ b/src/irisgl/src/irisglfwd.h
@@ -26,6 +26,7 @@ class LightNode;
 class ViewerNode;
 class ParticleSystemNode;
 class Mesh;
+class Frustum;
 class Material;
 class MeshNode;
 class VrDevice;

--- a/src/irisgl/src/math/intersectionhelper.h
+++ b/src/irisgl/src/math/intersectionhelper.h
@@ -14,14 +14,16 @@ For more information see the LICENSE file
 
 #include <QVector3D>
 #include <qmath.h>
+#include "../geometry/plane.h"
 
 namespace iris
 {
-
+/*
 struct Plane {
     QVector3D n; // Plane normal. Points x on the plane satisfy Dot(n,x) = d
     float d; // d = dot(n,p) for a given point p on the plane
 };
+*/
 
 class IntersectionHelper
 {
@@ -29,7 +31,7 @@ public:
     // Given three noncollinear points (ordered ccw), compute plane equation
     static Plane computePlaneND(QVector3D a, QVector3D b, QVector3D c) {
         Plane p = { QVector3D::crossProduct(b - a, c - a).normalized(),
-                    QVector3D::dotProduct(p.n, a) };
+                    QVector3D::dotProduct(p.normal, a) };
         return p;
     }
 
@@ -66,7 +68,7 @@ public:
     static int intersectSegmentPlane(QVector3D a, QVector3D b, Plane p, float &t, QVector3D &q) {
         // Compute the t value for the directed line ab intersecting the plane
         QVector3D ab = b - a;
-        t = (p.d - QVector3D::dotProduct(p.n, a)) / QVector3D::dotProduct(p.n, ab);
+        t = (p.d - QVector3D::dotProduct(p.normal, a)) / QVector3D::dotProduct(p.normal, ab);
         // If t in [0..1] compute and return intersection point
         if (t >= 0.0f && t <= 1.0f) {
             q = a + t * ab;

--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -254,11 +254,11 @@ QSharedPointer<iris::SceneNode> _buildScene(const aiScene* scene,aiNode* node,Sc
 
     //auto transform = node->mTransformation;
     node->mTransformation.Decompose(scale,rot,pos);
-    sceneNode->pos = QVector3D(pos.x,pos.y,pos.z);
-    sceneNode->scale = QVector3D(scale.x,scale.y,scale.z);
+    sceneNode->setLocalPos(QVector3D(pos.x,pos.y,pos.z));
+    sceneNode->setLocalScale(QVector3D(scale.x,scale.y,scale.z));
 
     //rot.Normalize();
-    sceneNode->rot = QQuaternion(rot.w,rot.x,rot.y,rot.z);
+    sceneNode->setLocalRot(QQuaternion(rot.w,rot.x,rot.y,rot.z));
 
     // this is probably the first node in the heirarchy
     // set it as the rootBone

--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -126,22 +126,36 @@ void MeshNode::setActiveMaterial(int type)
 
 void MeshNode::submitRenderItems()
 {
-    //if(!!rootBone) {
-    //    renderItem->worldMatrix = rootBone->globalTransform;
-    //}
-    //else
-        renderItem->worldMatrix = this->globalTransform;
+    if (visible) {
+        //if(!!rootBone) {
+        //    renderItem->worldMatrix = rootBone->globalTransform;
+        //}
+        //else
+            renderItem->worldMatrix = this->globalTransform;
+            renderItem->cullable = true;
+            renderItem->boundingSphere.pos = this->globalTransform.column(3).toVector3D();
+            renderItem->boundingSphere.radius = mesh->boundingSphere->radius * getMeshRadius();
 
-    if (!!material) {
-        renderItem->renderLayer = material->renderLayer;
-        //renderItem->faceCullingMode = faceCullingMode;
+        if (!!material) {
+            renderItem->renderLayer = material->renderLayer;
+            //renderItem->faceCullingMode = faceCullingMode;
+        }
+
+        this->scene->geometryRenderList.append(renderItem);
+
+        if (this->getShadowEnabled()) {
+            this->scene->shadowRenderList.append(renderItem);
+        }
     }
+}
 
-    this->scene->geometryRenderList.append(renderItem);
+float MeshNode::getMeshRadius()
+{
+    float scaleX = globalTransform.column(0).toVector3D().length();
+    float scaleY = globalTransform.column(1).toVector3D().length();
+    float scaleZ = globalTransform.column(2).toVector3D().length();
 
-    if (this->getShadowEnabled()) {
-        this->scene->shadowRenderList.append(renderItem);
-    }
+    return qMax(qMax(scaleX, scaleY), scaleZ);
 }
 
 /*

--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -46,7 +46,7 @@ namespace iris
 {
 
 MeshNode::MeshNode() {
-    mesh = nullptr;
+    //mesh = nullptr;
     sceneNodeType = SceneNodeType::Mesh;
 
     renderItem = new RenderItem();
@@ -88,13 +88,13 @@ void MeshNode::setMesh(QString source)
 }
 
 //should not be used on plain scene meshes
-void MeshNode::setMesh(Mesh* mesh)
+void MeshNode::setMesh(MeshPtr mesh)
 {
     this->mesh = mesh;
     renderItem->mesh = mesh;
 }
 
-Mesh* MeshNode::getMesh()
+MeshPtr MeshNode::getMesh()
 {
     return mesh;
 }
@@ -176,7 +176,7 @@ QJsonObject readJahShader(const QString &filePath)
  * @return
  */
 QSharedPointer<iris::SceneNode> _buildScene(const aiScene* scene,aiNode* node,SceneNodePtr rootBone, QString filePath,
-                                            std::function<MaterialPtr(Mesh* mesh, MeshMaterialData& data)> createMaterialFunc)
+                                            std::function<MaterialPtr(MeshPtr mesh, MeshMaterialData& data)> createMaterialFunc)
 {
     QSharedPointer<iris::SceneNode> sceneNode;// = QSharedPointer<iris::SceneNode>(new iris::SceneNode());
 
@@ -190,7 +190,7 @@ QSharedPointer<iris::SceneNode> _buildScene(const aiScene* scene,aiNode* node,Sc
         // aside from that, iris currently only renders meshes
         if(mesh->HasPositions())
         {
-            auto meshObj = new Mesh(mesh);
+            auto meshObj = MeshPtr(new Mesh(mesh));
             auto skel = Mesh::extractSkeleton(mesh, scene);
             meshObj->setSkeleton(skel);
 
@@ -222,7 +222,7 @@ QSharedPointer<iris::SceneNode> _buildScene(const aiScene* scene,aiNode* node,Sc
         for(unsigned i=0;i<node->mNumMeshes;i++)
         {
             auto mesh = scene->mMeshes[node->mMeshes[i]];
-            auto meshObj = new Mesh(mesh);
+            auto meshObj = MeshPtr(new Mesh(mesh));
             auto skel = Mesh::extractSkeleton(mesh, scene);
             meshObj->setSkeleton(skel);
 
@@ -276,7 +276,7 @@ QSharedPointer<iris::SceneNode> _buildScene(const aiScene* scene,aiNode* node,Sc
 }
 
 QSharedPointer<iris::SceneNode> MeshNode::loadAsSceneFragment(QString filePath,
-                                                              std::function<MaterialPtr(Mesh* mesh, MeshMaterialData& data)> createMaterialFunc)
+                                                              std::function<MaterialPtr(MeshPtr mesh, MeshMaterialData& data)> createMaterialFunc)
 {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(filePath.toStdString().c_str(),aiProcessPreset_TargetRealtime_Fast);
@@ -288,7 +288,7 @@ QSharedPointer<iris::SceneNode> MeshNode::loadAsSceneFragment(QString filePath,
         auto mesh = scene->mMeshes[0];
         auto node = iris::MeshNode::create();
 
-        auto meshObj = new Mesh(mesh);
+        auto meshObj = MeshPtr(new Mesh(mesh));
 
         //todo: use relative path from scene root
         auto anims = Mesh::extractAnimations(scene, filePath);

--- a/src/irisgl/src/scenegraph/meshnode.h
+++ b/src/irisgl/src/scenegraph/meshnode.h
@@ -28,7 +28,7 @@ struct MeshMaterialData;
 class MeshNode : public SceneNode
 {
 public:
-    Mesh* mesh;
+    MeshPtr mesh;
 
     QString meshPath;
 
@@ -61,14 +61,14 @@ public:
      * @param path
      * @return
      */
-    static SceneNodePtr loadAsSceneFragment(QString path, std::function<MaterialPtr(Mesh* mesh, MeshMaterialData& data)> createMaterialFunc);
+    static SceneNodePtr loadAsSceneFragment(QString path, std::function<MaterialPtr(MeshPtr mesh, MeshMaterialData& data)> createMaterialFunc);
 
     static SceneNodePtr loadAsAnimatedModel(QString path);
 
     void setMesh(QString source);
-    void setMesh(Mesh* mesh);
+    void setMesh(MeshPtr mesh);
 
-    Mesh* getMesh();
+    MeshPtr getMesh();
 
     void setMaterial(MaterialPtr material);
     void setCustomMaterial(MaterialPtr material);

--- a/src/irisgl/src/scenegraph/meshnode.h
+++ b/src/irisgl/src/scenegraph/meshnode.h
@@ -91,6 +91,7 @@ public:
 
     SceneNodePtr createDuplicate() override;
     virtual void submitRenderItems() override;
+    float getMeshRadius();
 
     //void updateAnimation(float time) override;
 

--- a/src/irisgl/src/scenegraph/scene.cpp
+++ b/src/irisgl/src/scenegraph/scene.cpp
@@ -15,6 +15,7 @@ For more information see the LICENSE file
 #include "../scenegraph/cameranode.h"
 #include "../scenegraph/viewernode.h"
 #include "../scenegraph/meshnode.h"
+#include "../scenegraph/particlesystemnode.h"
 #include "../graphics/mesh.h"
 #include "../graphics/renderitem.h"
 #include "../materials/defaultskymaterial.h"
@@ -56,6 +57,9 @@ Scene::Scene()
     fogEnabled = true;
 
     ambientColor = QColor(64, 64, 64);
+
+    meshes.reserve(100);
+    particleSystems.reserve(100);
 
     //reserve 1000 items initially
     geometryRenderList.reserve(1000);
@@ -103,6 +107,15 @@ void Scene::update(float dt)
     if (!!camera) {
         camera->update(dt);
         camera->updateCameraMatrices();
+    }
+
+    // add items to renderlist
+    for(auto& mesh : meshes) {
+        mesh->submitRenderItems();
+    }
+
+    for(auto& particle : particleSystems) {
+        particle->submitRenderItems();
     }
 
     this->geometryRenderList.append(skyRenderItem);

--- a/src/irisgl/src/scenegraph/scene.cpp
+++ b/src/irisgl/src/scenegraph/scene.cpp
@@ -163,9 +163,20 @@ void Scene::rayCast(const QSharedPointer<iris::SceneNode>& sceneNode,
 
 void Scene::addNode(SceneNodePtr node)
 {
+    if (!!node->scene)
+    {
+        //qDebug() << "Node already has scene";
+        //throw "Node already has scene";
+    }
+
     if (node->sceneNodeType == SceneNodeType::Light) {
         auto light = node.staticCast<iris::LightNode>();
         lights.append(light);
+    }
+
+    if (node->sceneNodeType == SceneNodeType::Mesh) {
+        auto mesh = node.staticCast<iris::MeshNode>();
+        meshes.append(mesh);
     }
 
     if(node->sceneNodeType == SceneNodeType::Viewer && vrViewer.isNull())
@@ -178,6 +189,10 @@ void Scene::removeNode(SceneNodePtr node)
 {
     if (node->sceneNodeType == SceneNodeType::Light) {
         lights.removeOne(node.staticCast<iris::LightNode>());
+    }
+
+    if (node->sceneNodeType == SceneNodeType::Mesh) {
+        meshes.removeOne(node.staticCast<iris::MeshNode>());
     }
 
     // if this node is the scene's viewer then reset the scene's viewer to null

--- a/src/irisgl/src/scenegraph/scene.h
+++ b/src/irisgl/src/scenegraph/scene.h
@@ -52,7 +52,7 @@ public:
     QList<MeshNodePtr> meshes;
     QList<ParticleSystemNodePtr> particleSystems;
 
-    Mesh* skyMesh;
+    MeshPtr skyMesh;
     Texture2DPtr skyTexture;
     QColor skyColor;
     QColor ambientColor;

--- a/src/irisgl/src/scenegraph/scene.h
+++ b/src/irisgl/src/scenegraph/scene.h
@@ -16,6 +16,7 @@ For more information see the LICENSE file
 #include "../irisglfwd.h"
 #include "../graphics/texture2d.h"
 #include "../materials/defaultskymaterial.h"
+#include "../geometry/frustum.h"
 
 namespace iris
 {
@@ -48,6 +49,7 @@ public:
     ViewerNodePtr vrViewer;
 
     QList<LightNodePtr> lights;
+    QList<MeshNodePtr> meshes;
 
     Mesh* skyMesh;
     Texture2DPtr skyTexture;

--- a/src/irisgl/src/scenegraph/scene.h
+++ b/src/irisgl/src/scenegraph/scene.h
@@ -50,6 +50,7 @@ public:
 
     QList<LightNodePtr> lights;
     QList<MeshNodePtr> meshes;
+    QList<ParticleSystemNodePtr> particleSystems;
 
     Mesh* skyMesh;
     Texture2DPtr skyTexture;

--- a/src/irisgl/src/scenegraph/scenenode.cpp
+++ b/src/irisgl/src/scenegraph/scenenode.cpp
@@ -254,8 +254,9 @@ void SceneNode::removeChild(SceneNodePtr node)
 {
     children.removeOne(node);
     node->parent = QSharedPointer<SceneNode>(nullptr);
-    node->setScene(QSharedPointer<Scene>(nullptr));
-    scene->removeNode(node);
+    //node->setScene(QSharedPointer<Scene>(nullptr));
+    //scene->removeNode(node);
+    node->removeFromScene();
 }
 
 bool SceneNode::isRootNode()

--- a/src/irisgl/src/scenegraph/scenenode.cpp
+++ b/src/irisgl/src/scenegraph/scenenode.cpp
@@ -176,8 +176,10 @@ void SceneNode::addChild(SceneNodePtr node, bool keepTransform)
 
     children.append(node);
     node->setParent(self);
-    node->setScene(self->scene);
-    scene->addNode(node);
+    if (!!scene) {
+        node->setScene(self->scene);
+        scene->addNode(node);
+    }
 
     if (keepTransform) {
         // @TODO: ensure global transform is calculated
@@ -370,18 +372,28 @@ void SceneNode::setParent(SceneNodePtr node)
 
 void SceneNode::setScene(ScenePtr scene)
 {
-    this->scene = scene;
+    // should not already be a part of scene
+    Q_ASSERT(!this->scene);
 
-    // the scene could be null, as in the case of a tree being built
-    // before being added to the scene
-    // @WARN -- this actually breaks the tree...
-    // if (!!scene) {
-    //     scene->addNode(sharedFromThis());
-    // }
+    this->scene = scene;
 
     // add children
     for (auto& child : children) {
         child->setScene(scene);
+    }
+}
+
+void SceneNode::removeFromScene()
+{
+    // should already have a scene to be removed from
+    Q_ASSERT(!!this->scene);
+
+    this->scene->removeNode(this->sharedFromThis());
+    this->scene.clear();
+
+    // add children
+    for (auto& child : children) {
+        child->removeFromScene();
     }
 }
 

--- a/src/irisgl/src/scenegraph/scenenode.cpp
+++ b/src/irisgl/src/scenegraph/scenenode.cpp
@@ -178,7 +178,7 @@ void SceneNode::addChild(SceneNodePtr node, bool keepTransform)
     node->setParent(self);
     if (!!scene) {
         node->setScene(self->scene);
-        scene->addNode(node);
+        //scene->addNode(node);
     }
 
     if (keepTransform) {
@@ -361,8 +361,8 @@ void SceneNode::update(float dt)
         child->update(dt);
     }
 
-    if (this->visible)
-        submitRenderItems();
+    //if (this->visible)
+    //    submitRenderItems();
 }
 
 void SceneNode::setParent(SceneNodePtr node)
@@ -376,6 +376,7 @@ void SceneNode::setScene(ScenePtr scene)
     Q_ASSERT(!this->scene);
 
     this->scene = scene;
+    this->scene->addNode(this->sharedFromThis());
 
     // add children
     for (auto& child : children) {

--- a/src/irisgl/src/scenegraph/scenenode.h
+++ b/src/irisgl/src/scenegraph/scenenode.h
@@ -40,14 +40,16 @@ protected:
     QList<AnimationPtr> animations;
     AnimationPtr animation;
 
+    QVector3D pos;
+    QVector3D scale;
+    QQuaternion rot;
+
+    bool transformDirty;
+    bool hasDirtyChildren;
 public:
     // cached local and global transform
     QMatrix4x4 localTransform;
     QMatrix4x4 globalTransform;
-
-    QVector3D pos;
-    QVector3D scale;
-    QQuaternion rot;
 
     SceneNodeType sceneNodeType;
 
@@ -90,6 +92,28 @@ public:
     bool isDuplicable() {
         return duplicable;
     }
+
+    QVector3D getLocalPos()
+    {
+        return pos;
+    }
+
+    QQuaternion getLocalRot()
+    {
+        return rot;
+    }
+
+    QVector3D getLocalScale()
+    {
+        return scale;
+    }
+
+    void setLocalPos(QVector3D pos);
+    void setLocalRot(QQuaternion rot);
+    void setLocalScale(QVector3D scale);
+
+    void setTransformDirty();
+    void setHasDirtyChildren();
 
     bool isAttached();
     void setAttached(bool attached);

--- a/src/irisgl/src/scenegraph/scenenode.h
+++ b/src/irisgl/src/scenegraph/scenenode.h
@@ -184,6 +184,7 @@ public:
 private:
     void setParent(SceneNodePtr node);
     void setScene(ScenePtr scene);
+    void removeFromScene();
 
     static long generateNodeId();
     static long nextId;

--- a/src/irisgl/src/scenegraph/viewernode.h
+++ b/src/irisgl/src/scenegraph/viewernode.h
@@ -28,7 +28,7 @@ class ViewerNode : public SceneNode
     ViewerNode();
 
 public:
-    Mesh* headModel;
+    MeshPtr headModel;
     ViewerMaterialPtr material;
 
     void setViewScale(float scale);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -322,7 +322,7 @@ iris::ScenePtr MainWindow::createDefaultScene()
     // second node
     auto node = iris::MeshNode::create();
     node->setMesh(":/app/models/ground.obj");
-    node->pos = QVector3D(0, 1e-4, 0); // prevent z-fighting with the default plane
+    node->setLocalPos(QVector3D(0, 1e-4, 0)); // prevent z-fighting with the default plane
     node->setName("Ground");
     node->setPickable(false);
     node->setShadowEnabled(false);
@@ -339,8 +339,8 @@ iris::ScenePtr MainWindow::createDefaultScene()
     dlight->setLightType(iris::LightType::Directional);
     scene->rootNode->addChild(dlight);
     dlight->setName("Directional Light");
-    dlight->pos = QVector3D(4, 4, 0);
-    dlight->rot = QQuaternion::fromEulerAngles(15, 0, 0);
+    dlight->setLocalPos(QVector3D(4, 4, 0));
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(15, 0, 0));
     dlight->intensity = 1;
     dlight->icon = iris::Texture2D::load(":/app/icons/light.png");
 
@@ -348,7 +348,7 @@ iris::ScenePtr MainWindow::createDefaultScene()
     plight->setLightType(iris::LightType::Point);
      scene->rootNode->addChild(plight);
     plight->setName("Point Light");
-    plight->pos = QVector3D(-4, 4, 0);
+    plight->setLocalPos(QVector3D(-4, 4, 0));
     plight->intensity = 1;
     plight->icon = iris::Texture2D::load(":/app/icons/bulb.png");
 
@@ -435,7 +435,7 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
                         if (sceneView->doActiveObjectPicking(evt->posF())) {
                             //activeSceneNode->pos = sceneView->hit;
                             dragScenePos = sceneView->hit;
-                        } else if (sceneView->updateRPI(sceneView->editorCam->pos,
+                        } else if (sceneView->updateRPI(sceneView->editorCam->getLocalPos(),
                                                         sceneView->calculateMouseRay(evt->posF())))
                         {
                             //activeSceneNode->pos = sceneView->Offset;
@@ -443,8 +443,8 @@ bool MainWindow::eventFilter(QObject *obj, QEvent *event)
                         } else {
                             ////////////////////////////////////////
                             const float spawnDist = 10.0f;
-                            auto offset = sceneView->editorCam->rot.rotatedVector(QVector3D(0, -1.0f, -spawnDist));
-                            offset += sceneView->editorCam->pos;
+                            auto offset = sceneView->editorCam->getLocalRot().rotatedVector(QVector3D(0, -1.0f, -spawnDist));
+                            offset += sceneView->editorCam->getLocalPos();
                             //activeSceneNode->pos = offset;
                             dragScenePos = offset;
                         }
@@ -1044,7 +1044,7 @@ void MainWindow::addMesh(const QString &path, bool ignore, QVector3D position)
 
 //    node->materialType = 2;
     //node->setName(nodeName);
-    node->pos = position;
+    node->setLocalPos(position);
 
     // todo: load material data
     addNodeToScene(node, ignore);
@@ -1117,9 +1117,9 @@ void MainWindow::addNodeToScene(QSharedPointer<iris::SceneNode> sceneNode, bool 
     // @TODO: add this to a constants file
     if (!ignore) {
         const float spawnDist = 10.0f;
-        auto offset = sceneView->editorCam->rot.rotatedVector(QVector3D(0, -1.0f, -spawnDist));
-        offset += sceneView->editorCam->pos;
-        sceneNode->pos = offset;
+        auto offset = sceneView->editorCam->getLocalRot().rotatedVector(QVector3D(0, -1.0f, -spawnDist));
+        offset += sceneView->editorCam->getLocalPos();
+        sceneNode->setLocalPos(offset);
     }
 
     // apply default material to mesh nodes

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1009,7 +1009,7 @@ void MainWindow::addMesh(const QString &path, bool ignore, QVector3D position)
     if (filename.isEmpty()) return;
 
     this->sceneView->makeCurrent();
-    auto node = iris::MeshNode::loadAsSceneFragment(filename,[](iris::Mesh* mesh, iris::MeshMaterialData& data)
+    auto node = iris::MeshNode::loadAsSceneFragment(filename,[](iris::MeshPtr mesh, iris::MeshMaterialData& data)
     {
         auto mat = iris::CustomMaterial::create();
         //MaterialReader *materialReader = new MaterialReader();

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -78,8 +78,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
     //camController = orbitalCam;
 
     editorCam = iris::CameraNode::create();
-    editorCam->pos = QVector3D(0, 5, 14);
-    editorCam->rot = QQuaternion::fromEulerAngles(-5, 0, 0);
+    editorCam->setLocalPos(QVector3D(0, 5, 14));
+    editorCam->setLocalRot(QQuaternion::fromEulerAngles(-5, 0, 0));
     camController->setCamera(editorCam);
 
     viewportMode = ViewportMode::Editor;
@@ -97,8 +97,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 
 void SceneViewWidget::resetEditorCam()
 {
-    editorCam->pos = QVector3D(0, 5, 14);
-    editorCam->rot = QQuaternion::fromEulerAngles(-5, 0, 0);
+    editorCam->setLocalPos(QVector3D(0, 5, 14));
+    editorCam->setLocalRot(QQuaternion::fromEulerAngles(-5, 0, 0));
     camController->setCamera(editorCam);
 }
 
@@ -288,7 +288,7 @@ bool SceneViewWidget::doActiveObjectPicking(const QPointF &point)
 {
     editorCam->updateCameraMatrices();
 
-    auto segStart = this->editorCam->pos;
+    auto segStart = this->editorCam->getLocalPos();
     auto rayDir = this->calculateMouseRay(point) * 1024;
     auto segEnd = segStart + rayDir;
 
@@ -317,7 +317,7 @@ void SceneViewWidget::mouseMoveEvent(QMouseEvent *e)
     QPointF dir = localPos - prevMousePos;
 
     if (e->buttons() == Qt::LeftButton && !!viewportGizmo->currentNode) {
-         viewportGizmo->update(editorCam->pos, calculateMouseRay(localPos));
+         viewportGizmo->update(editorCam->getLocalPos(), calculateMouseRay(localPos));
     }
 
     if (camController != nullptr) {
@@ -422,7 +422,7 @@ void SceneViewWidget::doObjectPicking(const QPointF& point, iris::SceneNodePtr l
 {
     editorCam->updateCameraMatrices();
 
-    auto segStart = this->editorCam->pos;
+    auto segStart = this->editorCam->getLocalPos();
     auto rayDir = this->calculateMouseRay(point) * 1024;
     auto segEnd = segStart + rayDir;
 
@@ -500,7 +500,7 @@ void SceneViewWidget::doGizmoPicking(const QPointF& point)
 {
     editorCam->updateCameraMatrices();
 
-    auto segStart = this->editorCam->pos;
+    auto segStart = this->editorCam->getLocalPos();
     auto rayDir = this->calculateMouseRay(point) * 1024;
     auto segEnd = segStart + rayDir;
 
@@ -524,7 +524,7 @@ void SceneViewWidget::doGizmoPicking(const QPointF& point)
 
     viewportGizmo->currentNode = hitList.last().hitNode;
 
-    viewportGizmo->onMousePress(editorCam->pos, this->calculateMouseRay(point) * 1024);
+    viewportGizmo->onMousePress(editorCam->getLocalPos(), this->calculateMouseRay(point) * 1024);
 }
 
 void SceneViewWidget::doScenePicking(const QSharedPointer<iris::SceneNode>& sceneNode,
@@ -618,7 +618,7 @@ void SceneViewWidget::doLightPicking(const QVector3D& segStart,
     for (auto light: scene->lights) {
         if (iris::IntersectionHelper::raySphereIntersects(segStart,
                                                           rayDir,
-                                                          light->pos,
+                                                          light->getLocalPos(),
                                                           lightRadius,
                                                           t, hitPoint))
         {

--- a/src/widgets/transformeditor.cpp
+++ b/src/widgets/transformeditor.cpp
@@ -52,9 +52,10 @@ void TransformEditor::onResetBtnClicked()
         yRotChanged(0);
         zRotChanged(0);
 
-        xScaleChanged(defaultStateNode->scale.x());
-        yScaleChanged(defaultStateNode->scale.x());
-        zScaleChanged(defaultStateNode->scale.x());
+        auto scale = defaultStateNode->getLocalScale();
+        xScaleChanged(scale.x());
+        yScaleChanged(scale.y());
+        zScaleChanged(scale.z());
 
         ui->xpos->setValue(0);
         ui->ypos->setValue(0);
@@ -64,9 +65,9 @@ void TransformEditor::onResetBtnClicked()
         ui->yrot->setValue(0);
         ui->zrot->setValue(0);
 
-        ui->xscale->setValue(defaultStateNode->scale.x());
-        ui->yscale->setValue(defaultStateNode->scale.y());
-        ui->zscale->setValue(defaultStateNode->scale.z());
+        ui->xscale->setValue(scale.x());
+        ui->yscale->setValue(scale.y());
+        ui->zscale->setValue(scale.z());
     }
 }
 
@@ -75,39 +76,47 @@ void TransformEditor::setSceneNode(QSharedPointer<iris::SceneNode> sceneNode)
     this->sceneNode = defaultStateNode = sceneNode;
 
     if (!!sceneNode) {
-        ui->xpos->setValue(sceneNode->pos.x());
-        ui->ypos->setValue(sceneNode->pos.y());
-        ui->zpos->setValue(sceneNode->pos.z());
+        auto pos = sceneNode->getLocalPos();
+        ui->xpos->setValue(pos.x());
+        ui->ypos->setValue(pos.y());
+        ui->zpos->setValue(pos.z());
 
-        auto rot = sceneNode->rot.toEulerAngles();
+        auto rot = sceneNode->getLocalRot().toEulerAngles();
         ui->xrot->setValue(rot.x());
         ui->yrot->setValue(rot.y());
         ui->zrot->setValue(rot.z());
 
-        ui->xscale->setValue(sceneNode->scale.x());
-        ui->yscale->setValue(sceneNode->scale.y());
-        ui->zscale->setValue(sceneNode->scale.z());
+        auto scale = sceneNode->getLocalScale();
+        ui->xscale->setValue(scale.x());
+        ui->yscale->setValue(scale.y());
+        ui->zscale->setValue(scale.z());
     }
 }
 
 void TransformEditor::xPosChanged(double value)
 {
     if (!!sceneNode) {
-        sceneNode->pos.setX(value);
+        auto pos = sceneNode->getLocalPos();
+        pos.setX(value);
+        sceneNode->setLocalPos(pos);
     }
 }
 
 void TransformEditor::yPosChanged(double value)
 {
     if (!!sceneNode) {
-        sceneNode->pos.setY(value);
+        auto pos = sceneNode->getLocalPos();
+        pos.setY(value);
+        sceneNode->setLocalPos(pos);
     }
 }
 
 void TransformEditor::zPosChanged(double value)
 {
     if (!!sceneNode) {
-        sceneNode->pos.setZ(value);
+        auto pos = sceneNode->getLocalPos();
+        pos.setZ(value);
+        sceneNode->setLocalPos(pos);
     }
 }
 
@@ -117,27 +126,27 @@ void TransformEditor::zPosChanged(double value)
 void TransformEditor::xRotChanged(double value)
 {
     if (!!sceneNode) {
-        auto rot = sceneNode->rot.toEulerAngles();
+        auto rot = sceneNode->getLocalRot().toEulerAngles();
         rot.setX(value);
-        sceneNode->rot = QQuaternion::fromEulerAngles(rot);
+        sceneNode->setLocalRot(QQuaternion::fromEulerAngles(rot));
     }
 }
 
 void TransformEditor::yRotChanged(double value)
 {
     if (!!sceneNode) {
-        auto rot = sceneNode->rot.toEulerAngles();
+        auto rot = sceneNode->getLocalRot().toEulerAngles();
         rot.setY(value);
-        sceneNode->rot = QQuaternion::fromEulerAngles(rot);
+        sceneNode->setLocalRot(QQuaternion::fromEulerAngles(rot));
     }
 }
 
 void TransformEditor::zRotChanged(double value)
 {
     if (!!sceneNode) {
-        auto rot = sceneNode->rot.toEulerAngles();
+        auto rot = sceneNode->getLocalRot().toEulerAngles();
         rot.setZ(value);
-        sceneNode->rot = QQuaternion::fromEulerAngles(rot);
+        sceneNode->setLocalRot(QQuaternion::fromEulerAngles(rot));
     }
 }
 
@@ -147,21 +156,27 @@ void TransformEditor::zRotChanged(double value)
 void TransformEditor::xScaleChanged(double value)
 {
     if (!!sceneNode) {
-        sceneNode->scale.setX(value);
+        auto scale = sceneNode->getLocalScale();
+        scale.setX(value);
+        sceneNode->setLocalScale(scale);
     }
 }
 
 void TransformEditor::yScaleChanged(double value)
 {
     if (!!sceneNode) {
-        sceneNode->scale.setY(value);
+        auto scale = sceneNode->getLocalScale();
+        scale.setY(value);
+        sceneNode->setLocalScale(scale);
     }
 }
 
 void TransformEditor::zScaleChanged(double value)
 {
     if (!!sceneNode) {
-        sceneNode->scale.setZ(value);
+        auto scale = sceneNode->getLocalScale();
+        scale.setZ(value);
+        sceneNode->setLocalScale(scale);
     }
 }
 


### PR DESCRIPTION
Added a few optimizations to the renderer:
Frustum culling
Scene node collects MeshNodes and render from them instead of walking entire tree
Only moved objects will have their transformations updated

Changes:
Replaced all instances or Mesh* with MeshPtr
Created getters and setters for scenenode's positon, location and scale