### PR TITLE
Added Undo/Redo for basic editor features

### DIFF
--- a/JahshakaVR.pro
+++ b/JahshakaVR.pro
@@ -99,7 +99,8 @@ SOURCES += src/main.cpp\
     src/core/database/database.cpp \
     src/core/database/projectdatabase.cpp \
     src/core/guidmanager.cpp \
-    src/commands/transfrormscenenodecommand.cpp
+    src/commands/transfrormscenenodecommand.cpp \
+    src/commands/changematerialpropertycommand.cpp
 
 HEADERS  += src/mainwindow.h \
     src/dialogs/renamelayerdialog.h \
@@ -193,7 +194,8 @@ HEADERS  += src/mainwindow.h \
     src/core/database/database.h \
     src/core/database/projectdatabase.h \
     src/core/guidmanager.h \
-    src/commands/transfrormscenenodecommand.h
+    src/commands/transfrormscenenodecommand.h \
+    src/commands/changematerialpropertycommand.h
 
 FORMS    += \
     src/dialogs/renamelayerdialog.ui \

--- a/JahshakaVR.pro
+++ b/JahshakaVR.pro
@@ -101,7 +101,8 @@ SOURCES += src/main.cpp\
     src/core/guidmanager.cpp \
     src/commands/transfrormscenenodecommand.cpp \
     src/commands/changematerialpropertycommand.cpp \
-    src/commands/addscenenodecommand.cpp
+    src/commands/addscenenodecommand.cpp \
+    src/commands/deletescenenodecommand.cpp
 
 HEADERS  += src/mainwindow.h \
     src/dialogs/renamelayerdialog.h \
@@ -197,7 +198,8 @@ HEADERS  += src/mainwindow.h \
     src/core/guidmanager.h \
     src/commands/transfrormscenenodecommand.h \
     src/commands/changematerialpropertycommand.h \
-    src/commands/addscenenodecommand.h
+    src/commands/addscenenodecommand.h \
+    src/commands/deletescenenodecommand.h
 
 FORMS    += \
     src/dialogs/renamelayerdialog.ui \

--- a/JahshakaVR.pro
+++ b/JahshakaVR.pro
@@ -100,7 +100,8 @@ SOURCES += src/main.cpp\
     src/core/database/projectdatabase.cpp \
     src/core/guidmanager.cpp \
     src/commands/transfrormscenenodecommand.cpp \
-    src/commands/changematerialpropertycommand.cpp
+    src/commands/changematerialpropertycommand.cpp \
+    src/commands/addscenenodecommand.cpp
 
 HEADERS  += src/mainwindow.h \
     src/dialogs/renamelayerdialog.h \
@@ -195,7 +196,8 @@ HEADERS  += src/mainwindow.h \
     src/core/database/projectdatabase.h \
     src/core/guidmanager.h \
     src/commands/transfrormscenenodecommand.h \
-    src/commands/changematerialpropertycommand.h
+    src/commands/changematerialpropertycommand.h \
+    src/commands/addscenenodecommand.h
 
 FORMS    += \
     src/dialogs/renamelayerdialog.ui \

--- a/JahshakaVR.pro
+++ b/JahshakaVR.pro
@@ -98,7 +98,8 @@ SOURCES += src/main.cpp\
     src/widgets/createanimationwidget.cpp \
     src/core/database/database.cpp \
     src/core/database/projectdatabase.cpp \
-    src/core/guidmanager.cpp
+    src/core/guidmanager.cpp \
+    src/commands/transfrormscenenodecommand.cpp
 
 HEADERS  += src/mainwindow.h \
     src/dialogs/renamelayerdialog.h \
@@ -191,7 +192,8 @@ HEADERS  += src/mainwindow.h \
     src/widgets/createanimationwidget.h \
     src/core/database/database.h \
     src/core/database/projectdatabase.h \
-    src/core/guidmanager.h
+    src/core/guidmanager.h \
+    src/commands/transfrormscenenodecommand.h
 
 FORMS    += \
     src/dialogs/renamelayerdialog.ui \

--- a/src/commands/addscenenodecommand.cpp
+++ b/src/commands/addscenenodecommand.cpp
@@ -1,0 +1,25 @@
+#include "addscenenodecommand.h"
+#include "../irisgl/src/scenegraph/scenenode.h"
+#include "../mainwindow.h"
+
+
+AddSceneNodeCommand::AddSceneNodeCommand(MainWindow* mainWindow, iris::SceneNodePtr parentNode, iris::SceneNodePtr sceneNode)
+{
+    this->mainWindow = mainWindow;
+    this->parentNode = parentNode;
+    this->sceneNode = sceneNode;
+}
+
+void AddSceneNodeCommand::undo()
+{
+    sceneNode->removeFromParent();
+    mainWindow->sceneNodeSelected(iris::SceneNodePtr());
+    mainWindow->repopulateSceneTree();
+}
+
+void AddSceneNodeCommand::redo()
+{
+    parentNode->addChild(sceneNode);
+    mainWindow->sceneNodeSelected(sceneNode);
+    mainWindow->repopulateSceneTree();
+}

--- a/src/commands/addscenenodecommand.h
+++ b/src/commands/addscenenodecommand.h
@@ -1,0 +1,22 @@
+#ifndef ADDSCENENODECOMMAND_H
+#define ADDSCENENODECOMMAND_H
+
+#include <QUndoCommand>
+#include "../irisglfwd.h"
+
+class MainWindow;
+
+class AddSceneNodeCommand : public QUndoCommand
+{
+    //iris::ScenePtr scene;
+    iris::SceneNodePtr parentNode;
+    iris::SceneNodePtr sceneNode;
+    MainWindow* mainWindow;
+public:
+    AddSceneNodeCommand(MainWindow* mainWindow, iris::SceneNodePtr parentNode, iris::SceneNodePtr sceneNode);
+
+    void undo() override;
+    void redo() override;
+};
+
+#endif // ADDSCENENODECOMMAND_H

--- a/src/commands/changematerialpropertycommand.cpp
+++ b/src/commands/changematerialpropertycommand.cpp
@@ -1,0 +1,40 @@
+#include "changematerialpropertycommand.h"
+#include "../irisgl/src/core/property.h"
+#include "../irisgl/src/materials/custommaterial.h"
+
+
+ChangeMaterialPropertyCommand::ChangeMaterialPropertyCommand(iris::CustomMaterialPtr material, QString name, QVariant oldValue, QVariant newValue)
+{
+    this->material = material;
+    propName = name;
+    this->newValue = newValue;
+    this->oldValue = oldValue;
+}
+
+void ChangeMaterialPropertyCommand::undo()
+{
+    setMaterialProperty(propName, oldValue);
+}
+
+void ChangeMaterialPropertyCommand::redo()
+{
+    setMaterialProperty(propName, newValue);
+}
+
+void ChangeMaterialPropertyCommand::setMaterialProperty(QString name, QVariant value)
+{
+    iris::Property* prop = nullptr;
+    for (auto property : material->properties) {
+        if (property->name == name)
+            prop = property;
+    }
+
+    Q_ASSERT(prop);
+
+    // special case for textures since we have to generate these
+    if (prop->type == iris::PropertyType::Texture) {
+        material->setTextureWithUniform(prop->uniform, value.toString());
+    } else {
+        prop->setValue(value);
+    }
+}

--- a/src/commands/changematerialpropertycommand.h
+++ b/src/commands/changematerialpropertycommand.h
@@ -1,0 +1,26 @@
+#ifndef CHANGEMATERIALPROPERTYCOMMAND_H
+#define CHANGEMATERIALPROPERTYCOMMAND_H
+
+#include <QUndoCommand>
+#include <QMatrix4x4>
+#include "../irisgl/src/irisglfwd.h"
+
+class ChangeMaterialPropertyCommand : public QUndoCommand
+{
+    iris::CustomMaterialPtr material;
+    QString propName;
+    QVariant oldValue;
+    QVariant newValue;
+
+
+public:
+    ChangeMaterialPropertyCommand(iris::CustomMaterialPtr material, QString name, QVariant oldValue, QVariant newValue);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    void setMaterialProperty(QString name, QVariant value);
+};
+
+#endif // CHANGEMATERIALPROPERTYCOMMAND_H

--- a/src/commands/deletescenenodecommand.cpp
+++ b/src/commands/deletescenenodecommand.cpp
@@ -1,0 +1,25 @@
+#include "deletescenenodecommand.h"
+#include "../irisgl/src/scenegraph/scenenode.h"
+#include "../mainwindow.h"
+
+DeleteSceneNodeCommand::DeleteSceneNodeCommand(MainWindow *mainWindow, iris::SceneNodePtr parentNode, iris::SceneNodePtr sceneNode)
+{
+    this->mainWindow = mainWindow;
+    this->parentNode = parentNode;
+    this->sceneNode = sceneNode;
+    this->position = parentNode->children.indexOf(sceneNode);
+}
+
+void DeleteSceneNodeCommand::undo()
+{
+    parentNode->insertChild(position, sceneNode);
+    mainWindow->sceneNodeSelected(sceneNode);
+    mainWindow->repopulateSceneTree();
+}
+
+void DeleteSceneNodeCommand::redo()
+{
+    sceneNode->removeFromParent();
+    mainWindow->sceneNodeSelected(iris::SceneNodePtr());
+    mainWindow->repopulateSceneTree();
+}

--- a/src/commands/deletescenenodecommand.h
+++ b/src/commands/deletescenenodecommand.h
@@ -1,0 +1,23 @@
+#ifndef DELETESCENENODECOMMAND_H
+#define DELETESCENENODECOMMAND_H
+
+#include <QUndoCommand>
+#include "../irisglfwd.h"
+
+class MainWindow;
+
+class DeleteSceneNodeCommand : public QUndoCommand
+{
+    iris::SceneNodePtr parentNode;
+    iris::SceneNodePtr sceneNode;
+    int position;
+    MainWindow* mainWindow;
+public:
+    DeleteSceneNodeCommand(MainWindow* mainWindow, iris::SceneNodePtr parentNode, iris::SceneNodePtr sceneNode);
+
+    void undo() override;
+    void redo() override;
+};
+
+
+#endif // DELETESCENENODECOMMAND_H

--- a/src/commands/transfrormscenenodecommand.cpp
+++ b/src/commands/transfrormscenenodecommand.cpp
@@ -1,0 +1,18 @@
+#include "transfrormscenenodecommand.h"
+
+TransformSceneNodeCommand::TransformSceneNodeCommand(iris::SceneNodePtr node, QMatrix4x4 localTransform)
+{
+    sceneNode = node;
+    oldTransform = node->getLocalTransformMatrix();
+    newTransform = localTransform;
+}
+
+void TransformSceneNodeCommand::undo()
+{
+    node->setLocalTransform(oldTransform);
+}
+
+void TransformSceneNodeCommand::redo()
+{
+    node->setLocalTransform(newTransform);
+}

--- a/src/commands/transfrormscenenodecommand.cpp
+++ b/src/commands/transfrormscenenodecommand.cpp
@@ -1,18 +1,19 @@
 #include "transfrormscenenodecommand.h"
+#include "../irisgl/src/scenegraph/scenenode.h"
 
 TransformSceneNodeCommand::TransformSceneNodeCommand(iris::SceneNodePtr node, QMatrix4x4 localTransform)
 {
     sceneNode = node;
-    oldTransform = node->getLocalTransformMatrix();
+    oldTransform = node->getLocalTransform();
     newTransform = localTransform;
 }
 
 void TransformSceneNodeCommand::undo()
 {
-    node->setLocalTransform(oldTransform);
+    sceneNode->setLocalTransform(oldTransform);
 }
 
 void TransformSceneNodeCommand::redo()
 {
-    node->setLocalTransform(newTransform);
+    sceneNode->setLocalTransform(newTransform);
 }

--- a/src/commands/transfrormscenenodecommand.h
+++ b/src/commands/transfrormscenenodecommand.h
@@ -1,0 +1,19 @@
+#ifndef TRANSFRORMSCENENODECOMMAND_H
+#define TRANSFRORMSCENENODECOMMAND_H
+
+#include <QUndoCommand>
+#include <QMatrix4x4>
+#include "../irisgl/src/irisglfwd.h"
+
+class TransformSceneNodeCommand : public QUndoCommand
+{
+    QMatrix4x4 oldTransform;
+    QMatrix4x4 newTransform;
+    iris::SceneNodePtr sceneNode;
+
+    TransformSceneNodeCommand(iris::SceneNodePtr node, QMatrix4x4 localTransform);
+    void undo() override;
+    void redo() override;
+}
+
+#endif // TRANSFRORMSCENENODECOMMAND_H

--- a/src/commands/transfrormscenenodecommand.h
+++ b/src/commands/transfrormscenenodecommand.h
@@ -10,10 +10,11 @@ class TransformSceneNodeCommand : public QUndoCommand
     QMatrix4x4 oldTransform;
     QMatrix4x4 newTransform;
     iris::SceneNodePtr sceneNode;
+public:
 
     TransformSceneNodeCommand(iris::SceneNodePtr node, QMatrix4x4 localTransform);
     void undo() override;
     void redo() override;
-}
+};
 
 #endif // TRANSFRORMSCENENODECOMMAND_H

--- a/src/editor/gizmoinstance.h
+++ b/src/editor/gizmoinstance.h
@@ -32,6 +32,7 @@ public:
     QSharedPointer<iris::CameraNode> camera;
     QSharedPointer<iris::SceneNode> hitNode;
     QString lastHitAxis;
+    QMatrix4x4 hitTransform;
 
     QString transformOrientation;
 

--- a/src/editor/gizmoinstance.h
+++ b/src/editor/gizmoinstance.h
@@ -18,10 +18,12 @@ class QOpenGLFunctions_3_2_Core;
 
 class GizmoInstance
 {
+protected:
+    QSharedPointer<iris::SceneNode> lastSelectedNode;
 public:
     QOpenGLFunctions_3_2_Core *gl;
 
-    QSharedPointer<iris::SceneNode> lastSelectedNode;
+
     QSharedPointer<iris::SceneNode> currentNode;
     QVector3D finalHitPoint;
     QVector3D translatePlaneNormal;
@@ -59,6 +61,20 @@ public:
     virtual void onMouseRelease() = 0;
 
     virtual void isGizmoHit(const iris::CameraNodePtr&, const QPointF&, const QVector3D&) = 0;
+
+    void setLastSelectedNode(const QSharedPointer<iris::SceneNode> &value)
+    {
+        lastSelectedNode = value;
+        if (!!lastSelectedNode)
+            hitTransform = lastSelectedNode->getLocalTransform();
+        else
+            hitTransform.setToIdentity();
+    }
+
+    QSharedPointer<iris::SceneNode> getLastSelectedNode() const
+    {
+        return lastSelectedNode;
+    }
 };
 
 #endif // GIZMOINSTANCE_H

--- a/src/editor/rotationgizmo.h
+++ b/src/editor/rotationgizmo.h
@@ -256,6 +256,14 @@ public:
         handles[(int) AxisHandle::X]->setHandleColor(QColor(231, 76, 60));
         handles[(int) AxisHandle::Y]->setHandleColor(QColor(46, 224, 113));
         handles[(int) AxisHandle::Z]->setHandleColor(QColor(37, 118, 235));
+
+        //add command here
+        if (!!lastSelectedNode) {
+            auto endTransform = lastSelectedNode->getLocalTransform();
+            // reset the transform because the command will re-apply the transform
+            lastSelectedNode->setLocalTransform(hitTransform);
+            UiManager::undoStack->push(new TransformSceneNodeCommand(lastSelectedNode, endTransform));
+        }
     }
 
     void isGizmoHit(const iris::CameraNodePtr& camera, const QPointF& pos, const QVector3D& rayDir) {
@@ -278,6 +286,7 @@ public:
 
         hitNode = hitList.last().hitNode;
         lastHitAxis = hitNode->getName();
+        hitTransform = lastSelectedNode->getLocalTransform();
     }
 
     void doMeshPicking(const QSharedPointer<iris::SceneNode>& sceneNode,

--- a/src/editor/scalegizmo.h
+++ b/src/editor/scalegizmo.h
@@ -202,6 +202,14 @@ public:
         handles[(int) AxisHandle::X]->setHandleColor(QColor(231, 76, 60));
         handles[(int) AxisHandle::Y]->setHandleColor(QColor(46, 224, 113));
         handles[(int) AxisHandle::Z]->setHandleColor(QColor(37, 118, 235));
+
+        //add command here
+        if (!!lastSelectedNode) {
+            auto endTransform = lastSelectedNode->getLocalTransform();
+            // reset the transform because the command will re-apply the transform
+            lastSelectedNode->setLocalTransform(hitTransform);
+            UiManager::undoStack->push(new TransformSceneNodeCommand(lastSelectedNode, endTransform));
+        }
     }
 
     void isGizmoHit(const iris::CameraNodePtr& camera, const QPointF& pos, const QVector3D& rayDir) {
@@ -224,6 +232,7 @@ public:
 
         hitNode = hitList.last().hitNode;
         lastHitAxis = hitNode->getName();
+        hitTransform = lastSelectedNode->getLocalTransform();
     }
 
     void doMeshPicking(const QSharedPointer<iris::SceneNode>& sceneNode,

--- a/src/editor/translationgizmo.h
+++ b/src/editor/translationgizmo.h
@@ -219,7 +219,7 @@ public:
         handles[(int) AxisHandle::Z]->setHandleColor(QColor(37, 118, 235));
 
         //add command here
-        if (!!hitNode) {
+        if (!!lastSelectedNode) {
             auto endTransform = lastSelectedNode->getLocalTransform();
             // reset the transform because the command will re-apply the transform
             lastSelectedNode->setLocalTransform(hitTransform);

--- a/src/editor/translationgizmo.h
+++ b/src/editor/translationgizmo.h
@@ -12,10 +12,15 @@ For more information see the LICENSE file
 #ifndef TRANSLATIONGIZMO_H
 #define TRANSLATIONGIZMO_H
 
+#include <QUndoStack>
+
 #include "gizmoinstance.h"
 #include "gizmohandle.h"
 #include "../irisgl/src/scenegraph/scene.h"
 #include "../irisgl/src/graphics/graphicshelper.h"
+#include "../uimanager.h"
+#include "../commands/transfrormscenenodecommand.h"
+
 
 class TranslationGizmo : public GizmoInstance
 {
@@ -212,6 +217,14 @@ public:
         handles[(int) AxisHandle::X]->setHandleColor(QColor(231, 76, 60));
         handles[(int) AxisHandle::Y]->setHandleColor(QColor(46, 224, 113));
         handles[(int) AxisHandle::Z]->setHandleColor(QColor(37, 118, 235));
+
+        //add command here
+        if (!!hitNode) {
+            auto endTransform = lastSelectedNode->getLocalTransform();
+            // reset the transform because the command will re-apply the transform
+            lastSelectedNode->setLocalTransform(hitTransform);
+            UiManager::undoStack->push(new TransformSceneNodeCommand(lastSelectedNode, endTransform));
+        }
     }
 
     void isGizmoHit(const iris::CameraNodePtr& camera, const QPointF& pos, const QVector3D& rayDir) {
@@ -234,6 +247,8 @@ public:
 
         hitNode = hitList.last().hitNode;
         lastHitAxis = hitNode->getName();
+        // record transform when hit for undo/redo
+        hitTransform = hitNode->getLocalTransform();
     }
 
     void doMeshPicking(const QSharedPointer<iris::SceneNode>& sceneNode,

--- a/src/editor/translationgizmo.h
+++ b/src/editor/translationgizmo.h
@@ -247,8 +247,7 @@ public:
 
         hitNode = hitList.last().hitNode;
         lastHitAxis = hitNode->getName();
-        // record transform when hit for undo/redo
-        hitTransform = hitNode->getLocalTransform();
+        hitTransform = lastSelectedNode->getLocalTransform();
     }
 
     void doMeshPicking(const QSharedPointer<iris::SceneNode>& sceneNode,

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -72,7 +72,8 @@ HEADERS += \
     $$PWD/src/core/property.h \
     $$PWD/src/geometry/boundingsphere.h \
     $$PWD/src/geometry/plane.h \
-    $$PWD/src/geometry/frustum.h
+    $$PWD/src/geometry/frustum.h \
+    $$PWD/src/math/transform.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)

--- a/src/irisgl/src/core/property.h
+++ b/src/irisgl/src/core/property.h
@@ -39,6 +39,8 @@ class PropertyListener
 {
 public:
     virtual void onPropertyChanged(Property*) = 0;
+    virtual void onPropertyChangeStart(Property*) = 0;
+    virtual void onPropertyChangeEnd(Property*) = 0;
 };
 
 struct BoolProperty : public Property

--- a/src/irisgl/src/math/mathhelper.h
+++ b/src/irisgl/src/math/mathhelper.h
@@ -23,18 +23,33 @@ class MathHelper
 {
 public:
 
+    // https://github.com/MonoGame/MonoGame/blob/develop/MonoGame.Framework/Matrix.cs#L1455
     static void decomposeMatrix(const QMatrix4x4& matrix, QVector3D& pos, QQuaternion& rot, QVector3D& scale)
     {
         pos = matrix.column(3).toVector3D();
         rot = QQuaternion::fromRotationMatrix(matrix.normalMatrix());
 
-        scale.setX(matrix.column(0).toVector3D().length());
-        scale.setY(matrix.column(1).toVector3D().length());
-        scale.setZ(matrix.column(2).toVector3D().length());
+        auto col = matrix.column(0);
+        auto sx = sign(col.x() * col.y() * col.z() * col.w()) < 0 ? -1 : 1;
+
+        col = matrix.column(1);
+        auto sy = sign(col.x() * col.y() * col.z() * col.w()) < 0 ? -1 : 1;
+
+        col = matrix.column(2);
+        auto sz = sign(col.x() * col.y() * col.z() * col.w()) < 0 ? -1 : 1;
+
+        scale.setX(sx * matrix.column(0).toVector3D().length());
+        scale.setY(sy * matrix.column(1).toVector3D().length());
+        scale.setZ(sz * matrix.column(2).toVector3D().length());
     }
 
     static float lerp(float norm, float min, float max) {
         return (max - min) * norm + min;
+    }
+
+    template <typename T>
+    static int sign(T val) {
+        return (T(0) < val) - (val < T(0));
     }
 };
 

--- a/src/irisgl/src/math/transform.h
+++ b/src/irisgl/src/math/transform.h
@@ -1,0 +1,27 @@
+#ifndef TRANSFORM_H
+#define TRANSFORM_H
+
+#include <QVector3D>
+#include <QMatrix4x4>
+
+namespace iris
+{
+
+class Transform
+{
+public:
+    QVector3D pos;
+    QQuaternion rot;
+    QVector3D scale;
+
+    QMatrix4x4 toMatrix()
+    {
+        QMatrix4x4 matrix;
+        matrix.setToIdentity();
+        return matrix;
+    }
+};
+
+}
+
+#endif // TRANSFORM_H

--- a/src/irisgl/src/scenegraph/scenenode.cpp
+++ b/src/irisgl/src/scenegraph/scenenode.cpp
@@ -21,6 +21,7 @@ For more information see the LICENSE file
 #include "../animation/keyframeanimation.h"
 #include "../animation/skeletalanimation.h"
 #include "../core/property.h"
+#include "../math/mathhelper.h"
 
 #include <functional>
 
@@ -96,11 +97,7 @@ void SceneNode::setLocalScale(QVector3D scale)
 
 void SceneNode::setLocalTransform(QMatrix4x4 transformMatrix)
 {
-    pos = transformMatrix.column(3).toVector3D();
-    rot = QQuaternion::fromRotationMatrix(transformMatrix.normalMatrix());
-    scale.setX(transformMatrix.column(0).toVector3D().length());
-    scale.setY(transformMatrix.column(1).toVector3D().length());
-    scale.setZ(transformMatrix.column(2).toVector3D().length());
+    MathHelper::decomposeMatrix(transformMatrix, pos, rot, scale);
     setTransformDirty();
 }
 

--- a/src/irisgl/src/scenegraph/scenenode.cpp
+++ b/src/irisgl/src/scenegraph/scenenode.cpp
@@ -211,6 +211,11 @@ SceneNodeType SceneNode::getSceneNodeType()
 
 void SceneNode::addChild(SceneNodePtr node, bool keepTransform)
 {
+    insertChild(children.size(), node, keepTransform);
+}
+
+void SceneNode::insertChild(int position, SceneNodePtr node, bool keepTransform)
+{
     auto initialGlobalTransform = node->getGlobalTransform();
 
     if (!!node->parent) {
@@ -220,7 +225,7 @@ void SceneNode::addChild(SceneNodePtr node, bool keepTransform)
     // @TODO: check if child is already a node
     auto self = sharedFromThis();
 
-    children.append(node);
+    children.insert(position, node);
     node->setParent(self);
     if (!!scene) {
         node->setScene(self->scene);

--- a/src/irisgl/src/scenegraph/scenenode.cpp
+++ b/src/irisgl/src/scenegraph/scenenode.cpp
@@ -94,6 +94,16 @@ void SceneNode::setLocalScale(QVector3D scale)
     setTransformDirty();
 }
 
+void SceneNode::setLocalTransform(QMatrix4x4 transformMatrix)
+{
+    pos = transformMatrix.column(3).toVector3D();
+    rot = QQuaternion::fromRotationMatrix(transformMatrix.normalMatrix());
+    scale.setX(transformMatrix.column(0).toVector3D().length());
+    scale.setY(transformMatrix.column(1).toVector3D().length());
+    scale.setZ(transformMatrix.column(2).toVector3D().length());
+    setTransformDirty();
+}
+
 void SceneNode::setTransformDirty()
 {
     transformDirty = true;

--- a/src/irisgl/src/scenegraph/scenenode.h
+++ b/src/irisgl/src/scenegraph/scenenode.h
@@ -181,6 +181,7 @@ public:
      * @param keepTransform keeps visual transform
      */
     void addChild(SceneNodePtr node, bool keepTransform = true);
+    void insertChild(int position, SceneNodePtr node, bool keepTransform = true);
     void removeFromParent();
     void removeChild(SceneNodePtr node);
 

--- a/src/irisgl/src/scenegraph/scenenode.h
+++ b/src/irisgl/src/scenegraph/scenenode.h
@@ -112,6 +112,8 @@ public:
     void setLocalRot(QQuaternion rot);
     void setLocalScale(QVector3D scale);
 
+    void setLocalTransform(QMatrix4x4 transformMatrix);
+
     void setTransformDirty();
     void setHasDirtyChildren();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -213,8 +213,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
     setupProjectDB();
 
-    undoStack = new QUndoStack(this);
-    UiManager::undoStack = undoStack;
+    setupUndoRedo();
 }
 
 void MainWindow::setupVrUi()
@@ -655,6 +654,18 @@ void MainWindow::stopAnimWidget()
 void MainWindow::setupProjectDB()
 {
     db = new Database();
+}
+
+void MainWindow::setupUndoRedo()
+{
+    undoStack = new QUndoStack(this);
+    UiManager::undoStack = undoStack;
+
+    connect(ui->actionUndo, SIGNAL(triggered(bool)), this, SLOT(undo()));
+    connect(ui->actionEditUndo, SIGNAL(triggered(bool)), this, SLOT(undo()));
+
+    connect(ui->actionRedo, SIGNAL(triggered(bool)), this, SLOT(redo()));
+    connect(ui->actionEditRedo, SIGNAL(triggered(bool)), this, SLOT(redo()));
 }
 
 void MainWindow::saveScene()
@@ -1218,6 +1229,18 @@ void MainWindow::updateSceneSettings()
 {
     scene->setOutlineWidth(prefsDialog->worldSettings->outlineWidth);
     scene->setOutlineColor(prefsDialog->worldSettings->outlineColor);
+}
+
+void MainWindow::undo()
+{
+    if (undoStack->canUndo())
+        undoStack->undo();
+}
+
+void MainWindow::redo()
+{
+    if (undoStack->canRedo())
+        undoStack->redo();
 }
 
 void MainWindow::newScene()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -211,6 +211,9 @@ MainWindow::MainWindow(QWidget *parent) :
 //    ui->PresetsDock->hide();
 
     setupProjectDB();
+
+    undoStack = new QUndoStack(this);
+    UiManager::undoStack = undoStack;
 }
 
 void MainWindow::setupVrUi()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -42,6 +42,7 @@ For more information see the LICENSE file
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <QOpenGLDebugLogger>
+#include <QUndoStack>
 
 #include <QFileDialog>
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -663,9 +663,11 @@ void MainWindow::setupUndoRedo()
 
     connect(ui->actionUndo, SIGNAL(triggered(bool)), this, SLOT(undo()));
     connect(ui->actionEditUndo, SIGNAL(triggered(bool)), this, SLOT(undo()));
+    ui->actionEditUndo->setShortcuts(QKeySequence::Undo);
 
     connect(ui->actionRedo, SIGNAL(triggered(bool)), this, SLOT(redo()));
     connect(ui->actionEditRedo, SIGNAL(triggered(bool)), this, SLOT(redo()));
+    ui->actionEditRedo->setShortcuts(QKeySequence::Redo);
 }
 
 void MainWindow::saveScene()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -87,6 +87,8 @@ For more information see the LICENSE file
 #include "uimanager.h"
 #include "core/database/database.h"
 
+#include "commands/addscenenodecommand.h"
+
 enum class VRButtonMode : int
 {
     Default = 0,
@@ -1149,9 +1151,18 @@ void MainWindow::addNodeToScene(QSharedPointer<iris::SceneNode> sceneNode, bool 
         }
     }
 
+    /*
     scene->getRootNode()->addChild(sceneNode, false);
     ui->sceneHierarchy->repopulateTree();
     sceneNodeSelected(sceneNode);
+    */
+    auto cmd = new AddSceneNodeCommand(this, scene->getRootNode(), sceneNode);
+    UiManager::undoStack->push(cmd);
+}
+
+void MainWindow::repopulateSceneTree()
+{
+    ui->sceneHierarchy->repopulateTree();
 }
 
 void MainWindow::duplicateNode()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -88,6 +88,7 @@ For more information see the LICENSE file
 #include "core/database/database.h"
 
 #include "commands/addscenenodecommand.h"
+#include "commands/deletescenenodecommand.h"
 
 enum class VRButtonMode : int
 {
@@ -1180,11 +1181,15 @@ void MainWindow::duplicateNode()
 void MainWindow::deleteNode()
 {
     if (!!activeSceneNode) {
+        /*
         activeSceneNode->removeFromParent();
         ui->sceneHierarchy->repopulateTree();
         sceneView->clearSelectedNode();
         ui->sceneNodeProperties->setSceneNode(QSharedPointer<iris::SceneNode>(nullptr));
         sceneView->hideGizmo();
+        */
+        auto cmd = new DeleteSceneNodeCommand(this, activeSceneNode->parent, activeSceneNode);
+        UiManager::undoStack->push(cmd);
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -118,6 +118,10 @@ public:
      */
     QString getAbsoluteAssetPath(QString relToApp);
 
+    void addNodeToActiveNode(QSharedPointer<iris::SceneNode> sceneNode);
+    void addNodeToScene(QSharedPointer<iris::SceneNode> sceneNode, bool ignore = false);
+    void repopulateSceneTree();
+
 private:
 
     /**
@@ -145,10 +149,6 @@ private:
     //void populateTree(QStandardItem* treeNode,SceneNode* sceneNode);
     //void populateTree(QTreeWidgetItem* treeNode,SceneNode* sceneNode);
     void deselectTreeItems();
-
-    //void addSceneNodeToSelectedTreeItem(QTreeWidget* sceneTree,SceneNode* newNode,bool addToSelected,QIcon icon);
-    void addNodeToActiveNode(QSharedPointer<iris::SceneNode> sceneNode);
-    void addNodeToScene(QSharedPointer<iris::SceneNode> sceneNode, bool ignore = false);
 
     void setupDefaultScene();
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -90,6 +90,7 @@ public:
     void stopAnimWidget();
 
     void setupProjectDB();
+    void setupUndoRedo();
 
     bool handleMousePress(QMouseEvent *event);
     bool handleMouseRelease(QMouseEvent *event);
@@ -230,6 +231,9 @@ public slots:
 
     void vrButtonClicked(bool);
     void updateSceneSettings();
+
+    void undo();
+    void redo();
 
 private slots:
     void translateGizmo();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -34,6 +34,7 @@ class QStandardItemModel;
 class QTreeWidgetItem;
 class QTreeWidget;
 class QIcon;
+class QUndoStack;
 
 //custom ui
 class TransformSlidersUi;
@@ -282,6 +283,8 @@ private:
     QActionGroup* cameraGroup;
 
     Database *db;
+
+    QUndoStack* undoStack;
 
     bool vrMode;
     QPushButton* vrButton;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -515,8 +515,8 @@ QWidget#addBtn:pressed, QWidget#deleteBtn:pressed {
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>994</width>
-     <height>32</height>
+     <width>1153</width>
+     <height>30</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -561,7 +561,15 @@ QWidget#addBtn:pressed, QWidget#deleteBtn:pressed {
     <addaction name="actionOpenWebsite"/>
     <addaction name="actionBlog"/>
    </widget>
+   <widget class="QMenu" name="menuEdit">
+    <property name="title">
+     <string>Edit</string>
+    </property>
+    <addaction name="actionUndo_2"/>
+    <addaction name="actionRedo_2"/>
+   </widget>
    <addaction name="menuFile"/>
+   <addaction name="menuEdit"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QDockWidget" name="sceneHierarchyDock">
@@ -752,7 +760,7 @@ QWidget#animationWidgetContents:hover {
           <x>0</x>
           <y>0</y>
           <width>394</width>
-          <height>582</height>
+          <height>578</height>
          </rect>
         </property>
         <property name="styleSheet">
@@ -1161,6 +1169,16 @@ QToolButton:checked
    </property>
    <property name="toolTip">
     <string>Arcball Camera</string>
+   </property>
+  </action>
+  <action name="actionUndo_2">
+   <property name="text">
+    <string>Undo</string>
+   </property>
+  </action>
+  <action name="actionRedo_2">
+   <property name="text">
+    <string>Redo</string>
    </property>
   </action>
  </widget>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -565,8 +565,8 @@ QWidget#addBtn:pressed, QWidget#deleteBtn:pressed {
     <property name="title">
      <string>Edit</string>
     </property>
-    <addaction name="actionUndo_2"/>
-    <addaction name="actionRedo_2"/>
+    <addaction name="actionEditUndo"/>
+    <addaction name="actionEditRedo"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
@@ -1171,12 +1171,12 @@ QToolButton:checked
     <string>Arcball Camera</string>
    </property>
   </action>
-  <action name="actionUndo_2">
+  <action name="actionEditUndo">
    <property name="text">
     <string>Undo</string>
    </property>
   </action>
-  <action name="actionRedo_2">
+  <action name="actionEditRedo">
    <property name="text">
     <string>Redo</string>
    </property>

--- a/src/uimanager.cpp
+++ b/src/uimanager.cpp
@@ -2,6 +2,7 @@
 
 
 AnimationWidget *UiManager::animationWidget = nullptr;
+QUndoStack *UiManager::undoStack = nullptr;
 
 AnimationWidget *UiManager::getAnimationWidget()
 {

--- a/src/uimanager.h
+++ b/src/uimanager.h
@@ -2,10 +2,12 @@
 #define UIMANAGER_H
 
 class AnimationWidget;
+class QUndoStack;
 
 class UiManager
 {
 public:
+    static QUndoStack* undoStack;
     static AnimationWidget* animationWidget;
 
     static AnimationWidget *getAnimationWidget();

--- a/src/widgets/hfloatsliderwidget.cpp
+++ b/src/widgets/hfloatsliderwidget.cpp
@@ -19,6 +19,8 @@ HFloatSliderWidget::HFloatSliderWidget(QWidget* parent) :
     ui->setupUi(this);
     connect(ui->spinbox,    SIGNAL(valueChanged(double)),   SLOT(onValueSpinboxChanged(double)));
     connect(ui->slider,     SIGNAL(valueChanged(int)),      SLOT(onValueSliderChanged(int)));
+    connect(ui->slider,     SIGNAL(sliderPressed()),        SLOT(sliderPressed()));
+    connect(ui->slider,     SIGNAL(sliderReleased()),       SLOT(sliderReleased()));
 
     precision = 1000.f;
     ui->slider->setRange(0, precision);
@@ -96,4 +98,14 @@ void HFloatSliderWidget::onValueSpinboxChanged(double val)
     ui->slider->blockSignals(false);
 
     emit valueChanged(this->value);
+}
+
+void HFloatSliderWidget::sliderPressed()
+{
+    emit valueChangeStart(this->value);
+}
+
+void HFloatSliderWidget::sliderReleased()
+{
+    emit valueChangeEnd(this->value);
 }

--- a/src/widgets/hfloatsliderwidget.h
+++ b/src/widgets/hfloatsliderwidget.h
@@ -40,9 +40,15 @@ public:
 signals:
     void valueChanged(float);
 
+    void valueChangeStart(float);
+    void valueChangeEnd(float);
+
 private slots:
     void onValueSliderChanged(int);
     void onValueSpinboxChanged(double);
+
+    void sliderPressed();
+    void sliderReleased();
 };
 
 #endif // HFLOATSLIDERWIDGET_H

--- a/src/widgets/propertywidget.cpp
+++ b/src/widgets/propertywidget.cpp
@@ -90,6 +90,26 @@ void PropertyWidget::addFloatProperty(iris::Property *prop)
 
         emit onPropertyChanged(fltProp);
     });
+
+    connect(fltWidget, &HFloatSliderWidget::valueChangeStart, this, [this, fltProp](float value) {
+        fltProp->value = value;
+
+        if (listener) {
+            listener->onPropertyChangeStart(fltProp);
+        }
+
+        emit onPropertyChanged(fltProp);
+    });
+
+    connect(fltWidget, &HFloatSliderWidget::valueChangeEnd, this, [this, fltProp](float value) {
+        fltProp->value = value;
+
+        if (listener) {
+            listener->onPropertyChangeEnd(fltProp);
+        }
+
+        emit onPropertyChanged(fltProp);
+    });
 }
 
 void PropertyWidget::addIntProperty(iris::Property *prop)

--- a/src/widgets/propertywidget.h
+++ b/src/widgets/propertywidget.h
@@ -46,6 +46,8 @@ public:
 
 signals:
     void onPropertyChanged(iris::Property*);
+    void onPropertyChangeStart(iris::Property*);
+    void onPropertyChangeEnd(iris::Property*);
 
 private:
     QList<iris::Property*> properties;

--- a/src/widgets/propertywidgets/materialpropertywidget.cpp
+++ b/src/widgets/propertywidgets/materialpropertywidget.cpp
@@ -127,6 +127,5 @@ void MaterialPropertyWidget::onPropertyChangeStart(iris::Property* prop)
 
 void MaterialPropertyWidget::onPropertyChangeEnd(iris::Property* prop)
 {
-    qDebug() << "Property End" << prop->getValue();
     UiManager::undoStack->push(new ChangeMaterialPropertyCommand(material, prop->name, startValue, prop->getValue()));
 }

--- a/src/widgets/propertywidgets/materialpropertywidget.cpp
+++ b/src/widgets/propertywidgets/materialpropertywidget.cpp
@@ -29,6 +29,9 @@ For more information see the LICENSE file
 #include "../../irisgl/src/materials/custommaterial.h"
 #include "../../irisgl/src/core/property.h"
 
+#include "../../uimanager.h"
+#include "../../commands/changematerialpropertycommand.h"
+
 void MaterialPropertyWidget::setSceneNode(QSharedPointer<iris::SceneNode> sceneNode)
 {
     if (!!sceneNode && sceneNode->getSceneNodeType() == iris::SceneNodeType::Mesh) {
@@ -114,4 +117,16 @@ void MaterialPropertyWidget::onPropertyChanged(iris::Property *prop)
     if (prop->type == iris::PropertyType::Texture) {
         material->setTextureWithUniform(prop->uniform, prop->getValue().toString());
     }
+
+}
+
+void MaterialPropertyWidget::onPropertyChangeStart(iris::Property* prop)
+{
+    startValue = prop->getValue();
+}
+
+void MaterialPropertyWidget::onPropertyChangeEnd(iris::Property* prop)
+{
+    qDebug() << "Property End" << prop->getValue();
+    UiManager::undoStack->push(new ChangeMaterialPropertyCommand(material, prop->name, startValue, prop->getValue()));
 }

--- a/src/widgets/propertywidgets/materialpropertywidget.h
+++ b/src/widgets/propertywidgets/materialpropertywidget.h
@@ -53,7 +53,12 @@ private:
     PropertyWidget* materialPropWidget;
 
     void setupShaderSelector();
-    void onPropertyChanged(iris::Property*);
+    void onPropertyChanged(iris::Property*) override;
+    void onPropertyChangeStart(iris::Property*) override;
+    void onPropertyChangeEnd(iris::Property*) override;
+
+    // for undo/redo
+    QVariant startValue;
 };
 
 #endif // MATERIALPROPERTYWIDGET_H

--- a/src/widgets/propertywidgets/postprocesspropertywidget.cpp
+++ b/src/widgets/propertywidgets/postprocesspropertywidget.cpp
@@ -23,3 +23,11 @@ void PostProcessPropertyWidget::onPropertyChanged(iris::Property *prop)
 {
     postProcess->setProperty(prop);
 }
+
+void PostProcessPropertyWidget::onPropertyChangeStart(iris::Property* prop)
+{
+}
+
+void PostProcessPropertyWidget::onPropertyChangeEnd(iris::Property* prop)
+{
+}

--- a/src/widgets/propertywidgets/postprocesspropertywidget.h
+++ b/src/widgets/propertywidgets/postprocesspropertywidget.h
@@ -22,7 +22,10 @@ public:
 
     // PropertyListener interface
 public:
-    void onPropertyChanged(iris::Property *);
+    void onPropertyChanged(iris::Property*) override;
+    void onPropertyChangeStart(iris::Property*) override;
+    void onPropertyChangeEnd(iris::Property*) override;
+
     PropertyWidget* propWidget;
     HFloatSliderWidget* slider;
 };

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -139,7 +139,7 @@ void SceneViewWidget::setSelectedNode(iris::SceneNodePtr sceneNode)
     renderer->setSelectedSceneNode(sceneNode);
 
     if (viewportGizmo != nullptr) {
-        viewportGizmo->lastSelectedNode = sceneNode;
+        viewportGizmo->setLastSelectedNode(sceneNode);
     }
 }
 
@@ -152,8 +152,8 @@ void SceneViewWidget::clearSelectedNode()
 void SceneViewWidget::updateScene(bool once)
 {
     // update and draw the 3d manipulation gizmo
-    if (!!viewportGizmo->lastSelectedNode) {
-        if (!viewportGizmo->lastSelectedNode->isRootNode()) {
+    if (!!viewportGizmo->getLastSelectedNode()) {
+        if (!viewportGizmo->getLastSelectedNode()->isRootNode()) {
             if (viewportMode != ViewportMode::VR) {
                 viewportGizmo->updateTransforms(editorCam->getGlobalPosition());
                 viewportGizmo->render(editorCam->viewMatrix, editorCam->projMatrix);
@@ -492,7 +492,7 @@ void SceneViewWidget::doObjectPicking(const QPointF& point, iris::SceneNodePtr l
 
     //viewportGizmo->lastSelectedNode = hitList.last().hitNode;
     //emit sceneNodeSelected(hitList.last().hitNode);
-    viewportGizmo->lastSelectedNode = pickedNode;
+    viewportGizmo->setLastSelectedNode(pickedNode);
     emit sceneNodeSelected(pickedNode);
 }
 
@@ -508,7 +508,7 @@ void SceneViewWidget::doGizmoPicking(const QPointF& point)
     doMeshPicking(viewportGizmo->getRootNode(), segStart, segEnd, hitList);
 
     if (hitList.size() == 0) {
-        viewportGizmo->lastSelectedNode = iris::SceneNodePtr();
+        viewportGizmo->setLastSelectedNode(iris::SceneNodePtr());
         viewportGizmo->currentNode = iris::SceneNodePtr();
         emit sceneNodeSelected(iris::SceneNodePtr());
         return;
@@ -690,7 +690,7 @@ void SceneViewWidget::setTransformOrientationGlobal()
 
 void SceneViewWidget::hideGizmo()
 {
-    viewportGizmo->lastSelectedNode = iris::SceneNodePtr();
+    viewportGizmo->setLastSelectedNode(iris::SceneNodePtr());
 }
 
 void SceneViewWidget::setGizmoLoc()
@@ -699,7 +699,7 @@ void SceneViewWidget::setGizmoLoc()
     transformMode = viewportGizmo->getTransformOrientation();
     viewportGizmo = translationGizmo;
     viewportGizmo->setTransformOrientation(transformMode);
-    viewportGizmo->lastSelectedNode = selectedNode;
+    viewportGizmo->setLastSelectedNode(selectedNode);
 }
 
 void SceneViewWidget::setGizmoRot()
@@ -708,7 +708,7 @@ void SceneViewWidget::setGizmoRot()
     transformMode = viewportGizmo->getTransformOrientation();
     viewportGizmo = rotationGizmo;
     viewportGizmo->setTransformOrientation(transformMode);
-    viewportGizmo->lastSelectedNode = selectedNode;
+    viewportGizmo->setLastSelectedNode(selectedNode);
 }
 
 void SceneViewWidget::setGizmoScale()
@@ -717,7 +717,7 @@ void SceneViewWidget::setGizmoScale()
     transformMode = viewportGizmo->getTransformOrientation();
     viewportGizmo = scaleGizmo;
     viewportGizmo->setTransformOrientation(transformMode);
-    viewportGizmo->lastSelectedNode = selectedNode;
+    viewportGizmo->setLastSelectedNode(selectedNode);
 }
 
 void SceneViewWidget::setEditorData(EditorData* data)


### PR DESCRIPTION
Undo/Redo was added for the following:
Adding a node to the scene
Deleting a node from the scene
Transforming a node (translation, rotation and scaling)
Slide-based material properties