### PR TITLE
Graphics Device class for interfacing with OpenGL

### DIFF
--- a/src/irisgl/assets.qrc
+++ b/src/irisgl/assets.qrc
@@ -36,5 +36,7 @@
         <file>assets/shaders/postprocesses/fxaa3_11.h</file>
         <file>assets/shaders/postprocesses/tonemapping.fs</file>
         <file>assets/shaders/postprocesses/aa.fs</file>
+        <file>assets/shaders/sprite.vert</file>
+        <file>assets/shaders/sprite.frag</file>
     </qresource>
 </RCC>

--- a/src/irisgl/assets/shaders/sprite.frag
+++ b/src/irisgl/assets/shaders/sprite.frag
@@ -1,0 +1,13 @@
+#version 150
+
+in vec4 v_color;
+in vec2 v_texCoord;
+
+uniform sampler2D tex;
+
+out vec4 fragColor;
+void main()
+{
+        vec4 finalCol = texture(tex, v_texCoord) * v_color;
+        fragColor = finalCol;
+}

--- a/src/irisgl/assets/shaders/sprite.vert
+++ b/src/irisgl/assets/shaders/sprite.vert
@@ -1,0 +1,19 @@
+#version 150
+
+in vec3 a_pos;
+in vec4 a_color;
+in vec2 a_texCoord;
+
+out vec4 v_color;
+out vec2 v_texCoord;
+
+uniform mat4 u_viewMatrix;
+uniform mat4 u_projMatrix;
+
+void main()
+{
+        gl_Position = u_projMatrix * u_viewMatrix * vec4(a_pos, 1.0);
+
+	v_color = a_color;
+	v_texCoord = a_texCoord;
+}

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -84,7 +84,8 @@ HEADERS += \
     $$PWD/src/postprocesses/fxaapostprocess.h \
     $$PWD/src/graphics/graphicsdevice.h \
     $$PWD/src/widgets/renderwidget.h \
-    $$PWD/src/graphics/spritebatch.h
+    $$PWD/src/graphics/spritebatch.h \
+    $$PWD/src/graphics/font.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -139,7 +140,8 @@ SOURCES += \
     $$PWD/src/postprocesses/fxaapostprocess.cpp \
     $$PWD/src/graphics/graphicsdevice.cpp \
     $$PWD/src/widgets/renderwidget.cpp \
-    $$PWD/src/graphics/spritebatch.cpp
+    $$PWD/src/graphics/spritebatch.cpp \
+    $$PWD/src/graphics/font.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -82,7 +82,8 @@ HEADERS += \
     $$PWD/src/graphics/utils/shapehelper.h \
     $$PWD/src/materials/colormaterial.h \
     $$PWD/src/postprocesses/fxaapostprocess.h \
-    $$PWD/src/graphics/graphicsdevice.h
+    $$PWD/src/graphics/graphicsdevice.h \
+    $$PWD/src/widgets/renderwidget.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -135,7 +136,8 @@ SOURCES += \
     $$PWD/src/graphics/utils/shapehelper.cpp \
     $$PWD/src/materials/colormaterial.cpp \
     $$PWD/src/postprocesses/fxaapostprocess.cpp \
-    $$PWD/src/graphics/graphicsdevice.cpp
+    $$PWD/src/graphics/graphicsdevice.cpp \
+    $$PWD/src/widgets/renderwidget.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -86,7 +86,8 @@ HEADERS += \
     $$PWD/src/widgets/renderwidget.h \
     $$PWD/src/graphics/spritebatch.h \
     $$PWD/src/graphics/font.h \
-    $$PWD/src/graphics/blendstate.h
+    $$PWD/src/graphics/blendstate.h \
+    $$PWD/src/graphics/depthstate.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -143,7 +144,8 @@ SOURCES += \
     $$PWD/src/widgets/renderwidget.cpp \
     $$PWD/src/graphics/spritebatch.cpp \
     $$PWD/src/graphics/font.cpp \
-    $$PWD/src/graphics/blendstate.cpp
+    $$PWD/src/graphics/blendstate.cpp \
+    $$PWD/src/graphics/depthstate.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -88,7 +88,8 @@ HEADERS += \
     $$PWD/src/graphics/font.h \
     $$PWD/src/graphics/blendstate.h \
     $$PWD/src/graphics/depthstate.h \
-    $$PWD/src/graphics/rasterizerstate.h
+    $$PWD/src/graphics/rasterizerstate.h \
+    $$PWD/src/content/contentmanager.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -147,7 +148,8 @@ SOURCES += \
     $$PWD/src/graphics/font.cpp \
     $$PWD/src/graphics/blendstate.cpp \
     $$PWD/src/graphics/depthstate.cpp \
-    $$PWD/src/graphics/rasterizerstate.cpp
+    $$PWD/src/graphics/rasterizerstate.cpp \
+    $$PWD/src/content/contentmanager.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -85,7 +85,8 @@ HEADERS += \
     $$PWD/src/graphics/graphicsdevice.h \
     $$PWD/src/widgets/renderwidget.h \
     $$PWD/src/graphics/spritebatch.h \
-    $$PWD/src/graphics/font.h
+    $$PWD/src/graphics/font.h \
+    $$PWD/src/graphics/blendstate.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -142,7 +142,8 @@ SOURCES += \
     $$PWD/src/graphics/graphicsdevice.cpp \
     $$PWD/src/widgets/renderwidget.cpp \
     $$PWD/src/graphics/spritebatch.cpp \
-    $$PWD/src/graphics/font.cpp
+    $$PWD/src/graphics/font.cpp \
+    $$PWD/src/graphics/blendstate.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -83,7 +83,8 @@ HEADERS += \
     $$PWD/src/materials/colormaterial.h \
     $$PWD/src/postprocesses/fxaapostprocess.h \
     $$PWD/src/graphics/graphicsdevice.h \
-    $$PWD/src/widgets/renderwidget.h
+    $$PWD/src/widgets/renderwidget.h \
+    $$PWD/src/graphics/spritebatch.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -137,7 +138,8 @@ SOURCES += \
     $$PWD/src/materials/colormaterial.cpp \
     $$PWD/src/postprocesses/fxaapostprocess.cpp \
     $$PWD/src/graphics/graphicsdevice.cpp \
-    $$PWD/src/widgets/renderwidget.cpp
+    $$PWD/src/widgets/renderwidget.cpp \
+    $$PWD/src/graphics/spritebatch.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -81,7 +81,8 @@ HEADERS += \
     $$PWD/src/graphics/utils/linemeshbuilder.h \
     $$PWD/src/graphics/utils/shapehelper.h \
     $$PWD/src/materials/colormaterial.h \
-    $$PWD/src/postprocesses/fxaapostprocess.h
+    $$PWD/src/postprocesses/fxaapostprocess.h \
+    $$PWD/src/graphics/graphicsdevice.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -133,7 +134,8 @@ SOURCES += \
     $$PWD/src/graphics/utils/linemeshbuilder.cpp \
     $$PWD/src/graphics/utils/shapehelper.cpp \
     $$PWD/src/materials/colormaterial.cpp \
-    $$PWD/src/postprocesses/fxaapostprocess.cpp
+    $$PWD/src/postprocesses/fxaapostprocess.cpp \
+    $$PWD/src/graphics/graphicsdevice.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/irisgl.pri
+++ b/src/irisgl/irisgl.pri
@@ -87,7 +87,8 @@ HEADERS += \
     $$PWD/src/graphics/spritebatch.h \
     $$PWD/src/graphics/font.h \
     $$PWD/src/graphics/blendstate.h \
-    $$PWD/src/graphics/depthstate.h
+    $$PWD/src/graphics/depthstate.h \
+    $$PWD/src/graphics/rasterizerstate.h
 
 include(src/assimp/assimp.pri)
 include(src/libovr/libovr.pri)
@@ -145,7 +146,8 @@ SOURCES += \
     $$PWD/src/graphics/spritebatch.cpp \
     $$PWD/src/graphics/font.cpp \
     $$PWD/src/graphics/blendstate.cpp \
-    $$PWD/src/graphics/depthstate.cpp
+    $$PWD/src/graphics/depthstate.cpp \
+    $$PWD/src/graphics/rasterizerstate.cpp
 
 RESOURCES += \
     $$PWD/assets.qrc

--- a/src/irisgl/src/content/contentmanager.cpp
+++ b/src/irisgl/src/content/contentmanager.cpp
@@ -1,0 +1,48 @@
+#include "contentmanager.h"
+#include "../graphics/graphicsdevice.h"
+#include "../graphics/mesh.h"
+#include "../graphics/texture2d.h"
+#include "../graphics/font.h"
+#include "../graphics/shader.h"
+
+namespace iris
+{
+
+ContentManager::ContentManager(GraphicsDevicePtr graphics)
+{
+    this->graphics = graphics;
+}
+
+MeshPtr ContentManager::loadMesh(QString meshPath)
+{
+    return Mesh::loadMesh(meshPath);
+}
+
+Texture2DPtr ContentManager::loadTexture(QString texturePath, bool flipY)
+{
+    return Texture2D::load(texturePath, flipY);
+}
+
+FontPtr ContentManager::loadDefaultFont(int size)
+{
+    return Font::create(graphics, size);
+}
+
+FontPtr ContentManager::loadFont(QString fontName, int size)
+{
+    return Font::create(graphics, fontName, size);
+}
+
+ShaderPtr ContentManager::loadShader(QString vertexShaderPath, QString fragmentShaderPath)
+{
+    return Shader::load(graphics->getGL(), vertexShaderPath, fragmentShaderPath);
+}
+
+ContentManagerPtr ContentManager::create(GraphicsDevicePtr graphics)
+{
+    return ContentManagerPtr(new ContentManager(graphics));
+}
+
+
+
+}

--- a/src/irisgl/src/content/contentmanager.h
+++ b/src/irisgl/src/content/contentmanager.h
@@ -1,0 +1,29 @@
+#ifndef CONTENTMANAGER_H
+#define CONTENTMANAGER_H
+
+#include "../irisglfwd.h"
+
+
+namespace iris
+{
+
+// this class is in charge of loading and caching all assets
+class ContentManager
+{
+    GraphicsDevicePtr graphics;
+
+    ContentManager(GraphicsDevicePtr graphics);
+public:
+    MeshPtr loadMesh(QString meshPath);
+    Texture2DPtr loadTexture(QString texturePath, bool flipY = false);
+    FontPtr loadDefaultFont(int size = 15);
+    FontPtr loadFont(QString fontPath, int size = 15);
+    ShaderPtr loadShader(QString vertexShaderPath, QString fragmentShaderPath);
+
+    static ContentManagerPtr create(GraphicsDevicePtr graphics);
+};
+
+
+}
+
+#endif // CONTENTMANAGER_H

--- a/src/irisgl/src/graphics/blendstate.cpp
+++ b/src/irisgl/src/graphics/blendstate.cpp
@@ -1,0 +1,10 @@
+#include "blendstate.h"
+
+namespace iris
+{
+
+BlendState BlendState::AlphaBlend = BlendState(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+BlendState BlendState::Opaque = BlendState(GL_ONE, GL_ZERO);
+BlendState BlendState::Additive = BlendState(GL_ONE, GL_ONE);
+
+}

--- a/src/irisgl/src/graphics/blendstate.h
+++ b/src/irisgl/src/graphics/blendstate.h
@@ -1,6 +1,8 @@
 #ifndef BLENDSTATE_H
 #define BLENDSTATE_H
 
+#include <qopengl.h>
+
 namespace iris
 {
 
@@ -14,6 +16,30 @@ struct BlendState
 
     GLenum colorBlendEquation;
     GLenum alphaBlendEquation;
+
+    BlendState()
+    {
+        colorSourceBlend = GL_ONE;
+        alphaSourceBlend = GL_ONE;
+        colorDestBlend = GL_ZERO;
+        alphaDestBlend = GL_ZERO;
+
+        colorBlendEquation = GL_FUNC_ADD;
+        alphaBlendEquation = GL_FUNC_ADD;
+    }
+
+    BlendState(GLenum sourceBlend, GLenum destBlend):
+        BlendState()
+    {
+        colorSourceBlend = sourceBlend;
+        alphaSourceBlend = sourceBlend;
+        colorDestBlend = destBlend;
+        alphaDestBlend = destBlend;
+    }
+
+    static BlendState AlphaBlend;
+    static BlendState Opaque;
+    static BlendState Additive;
 };
 
 }

--- a/src/irisgl/src/graphics/blendstate.h
+++ b/src/irisgl/src/graphics/blendstate.h
@@ -1,0 +1,20 @@
+#ifndef BLENDSTATE_H
+#define BLENDSTATE_H
+
+namespace iris
+{
+
+struct BlendState
+{
+    //bool blendEnabled;
+    GLenum colorSourceBlend;
+    GLenum alphaSourceBlend;
+    GLenum colorDestBlend;
+    GLenum alphaDestBlend;
+
+    GLenum colorBlendEquation;
+    GLenum alphaBlendEquation;
+};
+
+}
+#endif // BLENDSTATE_H

--- a/src/irisgl/src/graphics/depthstate.cpp
+++ b/src/irisgl/src/graphics/depthstate.cpp
@@ -1,0 +1,9 @@
+#include "depthstate.h"
+
+namespace iris
+{
+
+DepthState DepthState::Default = DepthState(true, true);
+DepthState DepthState::None = DepthState(false, false);
+
+}

--- a/src/irisgl/src/graphics/depthstate.h
+++ b/src/irisgl/src/graphics/depthstate.h
@@ -1,0 +1,34 @@
+#ifndef DEPTHSTENCILSTATE_H
+#define DEPTHSTENCILSTATE_H
+
+#include <qopengl.h>
+
+namespace iris {
+
+struct DepthState
+{
+    bool depthBufferEnabled;
+    bool depthWriteEnabled;
+    GLenum depthCompareFunc;
+
+    DepthState()
+    {
+        depthBufferEnabled = true;
+        depthWriteEnabled = true;
+        depthCompareFunc = GL_LEQUAL;
+    }
+
+    DepthState(bool bufferEnabled, bool writeEnabled)
+    {
+        depthBufferEnabled = bufferEnabled;
+        depthWriteEnabled = writeEnabled;
+        depthCompareFunc = GL_LEQUAL;
+    }
+
+    static DepthState Default;
+    static DepthState None;
+};
+
+}
+
+#endif // DEPTHSTENCILSTATE_H

--- a/src/irisgl/src/graphics/font.cpp
+++ b/src/irisgl/src/graphics/font.cpp
@@ -1,0 +1,69 @@
+#include "font.h"
+#include "../irisglfwd.h"
+#include "texture2d.h"
+#include <QFont>
+#include <QFontMetrics>
+#include <QPixmap>
+#include <QPainter>
+#include <QMap>
+
+namespace iris
+{
+
+Font::Font(GraphicsDevicePtr graphics, QString fontName)
+{
+    this->graphics = graphics;
+    font = QFont("Arial",8);
+    metrics = new QFontMetrics(font);
+
+//    Glyph glyph;
+//    createGlyph(QChar('a'),glyph);
+//    glyphs.insert(QChar('a'),glyph);
+    QString chars = " abcdefghijklmnopqrstuvwxyzBCDEFGHIJKLMNOPQRSTUVWXZY1234567890._-/!A";
+
+    for(auto chr : chars) {
+        Glyph glyph;
+        createGlyph(QChar(chr),glyph);
+        glyphs.insert(QChar(chr),glyph);
+    }
+}
+
+void Font::createGlyph(QChar chr, Glyph &glyph)
+{
+    int charWidth = metrics->width(chr);
+    int charHeight = metrics->height();
+    //QPixmap* pixmap = new QPixmap(charWidth, charHeight);
+
+    QImage image(charWidth, charHeight, QImage::Format_ARGB32);
+    image.fill(0);
+
+    QPainter painter;
+    painter.begin(&image);
+    //painter.eraseRect(0, 0, image.width(), image.height());
+    painter.setFont(font);
+    painter.setPen(QColor(255, 255, 255, 255));
+    painter.setBrush(QBrush(QColor(255, 255, 255, 255)));
+    painter.drawText(0, charHeight, chr);
+    painter.end();
+
+    //auto gl = device->getGL();
+    //QImage image = pixmap->toImage();
+    image.save("/home/nicolas/Desktop/image.png");
+    glyph.chr = chr;
+    glyph.tex = Texture2D::create(image);
+    glyph.tex->setWrapMode(QOpenGLTexture::ClampToEdge, QOpenGLTexture::ClampToEdge);
+    glyph.tex->setFilters(QOpenGLTexture::Nearest, QOpenGLTexture::Nearest);
+    glyph.width = charWidth;
+    glyph.height = charHeight;
+    //glyph.pixmap = pixmap;
+
+    //delete pixmap;
+}
+
+FontPtr Font::create(GraphicsDevicePtr graphics)
+{
+    return FontPtr(new Font(graphics, ""));
+}
+
+
+}

--- a/src/irisgl/src/graphics/font.cpp
+++ b/src/irisgl/src/graphics/font.cpp
@@ -6,20 +6,22 @@
 #include <QPixmap>
 #include <QPainter>
 #include <QMap>
+#include <QDebug>
 
 namespace iris
 {
 
+// https://github.com/libgdx/libgdx/blob/master/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
 Font::Font(GraphicsDevicePtr graphics, QString fontName)
 {
     this->graphics = graphics;
-    font = QFont("Arial",8);
+    font = QFont("Arial",16);
     metrics = new QFontMetrics(font);
 
 //    Glyph glyph;
 //    createGlyph(QChar('a'),glyph);
 //    glyphs.insert(QChar('a'),glyph);
-    QString chars = " abcdefghijklmnopqrstuvwxyzBCDEFGHIJKLMNOPQRSTUVWXZY1234567890._-/!A";
+    QString chars = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890\"!`?'.,;:()[]{}<>|/@\\^$€-%+=#_&~*";
 
     for(auto chr : chars) {
         Glyph glyph;
@@ -43,7 +45,7 @@ void Font::createGlyph(QChar chr, Glyph &glyph)
     painter.setFont(font);
     painter.setPen(QColor(255, 255, 255, 255));
     painter.setBrush(QBrush(QColor(255, 255, 255, 255)));
-    painter.drawText(0, charHeight, chr);
+    painter.drawText(0, metrics->ascent(), chr);
     painter.end();
 
     // convert luminance to alpha to make texture blend properly
@@ -51,7 +53,8 @@ void Font::createGlyph(QChar chr, Glyph &glyph)
     for(int x = 0;x<image.width(); x++) {
         for(int y = 0;y<image.height(); y++) {
             auto pixel = image.pixelColor(x,y);
-            if (pixel.alpha()!=0) {
+            //qDebug()<<pixel.alpha();
+            if (pixel.alpha()>0) {
                 // make pixel white and use luminance as alpha
                 // can just use red() since r,g and b are the same
                 image.setPixelColor(x,y,QColor(255, 255, 255, pixel.red()));

--- a/src/irisgl/src/graphics/font.cpp
+++ b/src/irisgl/src/graphics/font.cpp
@@ -12,10 +12,10 @@ namespace iris
 {
 
 // https://github.com/libgdx/libgdx/blob/master/extensions/gdx-freetype/src/com/badlogic/gdx/graphics/g2d/freetype/FreeTypeFontGenerator.java
-Font::Font(GraphicsDevicePtr graphics, QString fontName)
+Font::Font(GraphicsDevicePtr graphics, QString fontName, int fontSize)
 {
     this->graphics = graphics;
-    font = QFont("Arial",16);
+    font = QFont(fontName, fontSize);
     metrics = new QFontMetrics(font);
 
 //    Glyph glyph;
@@ -72,15 +72,16 @@ void Font::createGlyph(QChar chr, Glyph &glyph)
     glyph.tex->setFilters(QOpenGLTexture::Nearest, QOpenGLTexture::Nearest);
     glyph.width = charWidth;
     glyph.height = charHeight;
-    //glyph.pixmap = pixmap;
-
-    //delete pixmap;
 }
 
-FontPtr Font::create(GraphicsDevicePtr graphics)
+FontPtr Font::create(GraphicsDevicePtr graphics, int size)
 {
-    return FontPtr(new Font(graphics, ""));
+    return FontPtr(new Font(graphics, "Arial", size));
 }
 
+FontPtr Font::create(GraphicsDevicePtr graphics, QString fontName, int size)
+{
+    return FontPtr(new Font(graphics, fontName, size));
+}
 
 }

--- a/src/irisgl/src/graphics/font.cpp
+++ b/src/irisgl/src/graphics/font.cpp
@@ -46,6 +46,20 @@ void Font::createGlyph(QChar chr, Glyph &glyph)
     painter.drawText(0, charHeight, chr);
     painter.end();
 
+    // convert luminance to alpha to make texture blend properly
+    // when using GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA
+    for(int x = 0;x<image.width(); x++) {
+        for(int y = 0;y<image.height(); y++) {
+            auto pixel = image.pixelColor(x,y);
+            if (pixel.alpha()!=0) {
+                // make pixel white and use luminance as alpha
+                // can just use red() since r,g and b are the same
+                image.setPixelColor(x,y,QColor(255, 255, 255, pixel.red()));
+            }
+
+        }
+    }
+
     //auto gl = device->getGL();
     //QImage image = pixmap->toImage();
     image.save("/home/nicolas/Desktop/image.png");

--- a/src/irisgl/src/graphics/font.h
+++ b/src/irisgl/src/graphics/font.h
@@ -31,11 +31,12 @@ public:
     QMap<QChar, Glyph> glyphs;
     GraphicsDevicePtr graphics;
 
-    Font(GraphicsDevicePtr graphics, QString fontName);
+    Font(GraphicsDevicePtr graphics, QString fontName, int fontSize);
 
     void createGlyph(QChar chr, Glyph& glyph);
 
-    static FontPtr create(GraphicsDevicePtr graphics);
+    static FontPtr create(GraphicsDevicePtr graphics, int size = 16);
+    static FontPtr create(GraphicsDevicePtr graphics, QString fontName, int size = 16);
 };
 
 }

--- a/src/irisgl/src/graphics/font.h
+++ b/src/irisgl/src/graphics/font.h
@@ -1,0 +1,43 @@
+#ifndef FONT_H
+#define FONT_H
+
+#include "../irisglfwd.h"
+#include <QFont>
+#include <QChar>
+#include <QPixmap>
+#include <QMap>
+
+class QFont;
+class QFontMetrics;
+
+namespace iris
+{
+
+struct Glyph
+{
+    Texture2DPtr tex;
+    QPixmap pixmap;
+    QChar chr;
+
+    int width;
+    int height;
+};
+
+class Font
+{
+public:
+    QFont font;
+    QFontMetrics* metrics;
+    QMap<QChar, Glyph> glyphs;
+    GraphicsDevicePtr graphics;
+
+    Font(GraphicsDevicePtr graphics, QString fontName);
+
+    void createGlyph(QChar chr, Glyph& glyph);
+
+    static FontPtr create(GraphicsDevicePtr graphics);
+};
+
+}
+
+#endif // FONT_H

--- a/src/irisgl/src/graphics/forwardrenderer.cpp
+++ b/src/irisgl/src/graphics/forwardrenderer.cpp
@@ -37,6 +37,7 @@ For more information see the LICENSE file
 #include "texture2d.h"
 #include "rendertarget.h"
 #include "renderlist.h"
+#include "graphicsdevice.h"
 #include "../vr/vrdevice.h"
 #include "../vr/vrmanager.h"
 #include "../core/irisutils.h"
@@ -63,6 +64,7 @@ namespace iris
 ForwardRenderer::ForwardRenderer()
 {
     this->gl = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_2_Core>();
+    graphics = GraphicsDevice::create();
     renderData = new RenderData();
 
     billboard = new Billboard(gl);

--- a/src/irisgl/src/graphics/forwardrenderer.h
+++ b/src/irisgl/src/graphics/forwardrenderer.h
@@ -49,6 +49,7 @@ class PerformanceTimer;
 class ForwardRenderer
 {
     QOpenGLFunctions_3_2_Core* gl;
+    GraphicsDevicePtr graphics;
     RenderData* renderData;
 
     /**

--- a/src/irisgl/src/graphics/forwardrenderer.h
+++ b/src/irisgl/src/graphics/forwardrenderer.h
@@ -50,6 +50,7 @@ class ForwardRenderer
 {
     QOpenGLFunctions_3_2_Core* gl;
     GraphicsDevicePtr graphics;
+
     RenderData* renderData;
 
     /**
@@ -82,6 +83,8 @@ class ForwardRenderer
     PerformanceTimer* perfTimer;
 
 public:
+
+    GraphicsDevicePtr getGraphicsDevice();
 
     /**
      * Sets selected scene node. If this node is a mesh, it is rendered in wireframe mode

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -3,9 +3,32 @@
 #include "graphicsdevice.h"
 #include "rendertarget.h"
 #include "texture2d.h"
+#include "vertexlayout.h"
 
 namespace iris
 {
+
+VertexBuffer::VertexBuffer(GraphicsDevicePtr device, VertexLayout vertexLayout)
+{
+    this->device = device;
+    this->vertexLayout = vertexLayout;
+    device->getGL()->glGenBuffers(1, &bufferId);
+}
+
+void VertexBuffer::setData(void *data, unsigned int sizeInBytes)
+{
+    memcpy(this->data, data, sizeInBytes);
+
+    auto gl = device->getGL();
+    gl->glBindBuffer(GL_ARRAY_BUFFER, bufferId);
+    gl->glBufferData(GL_ARRAY_BUFFER, sizeInBytes, data, GL_STATIC_DRAW);
+    gl->glBindBuffer(GL_ARRAY_BUFFER, bufferId);
+}
+
+QOpenGLFunctions_3_2_Core *GraphicsDevice::getGL() const
+{
+    return gl;
+}
 
 GraphicsDevice::GraphicsDevice()
 {
@@ -93,6 +116,8 @@ void GraphicsDevice::clearTexture(int target)
     gl->glBindTexture(GL_TEXTURE_2D, 0);
     gl->glActiveTexture(GL_TEXTURE0);
 }
+
+
 
 
 

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -52,6 +52,7 @@ GraphicsDevice::GraphicsDevice()
     //set default blend and depth state
     this->setBlendState(BlendState::Opaque);
     this->setDepthState(DepthState::Default);
+    this->setRasterizerState(RasterizerState::CullCounterClockwise);
 }
 
 void GraphicsDevice::setViewport(const QRect& vp)
@@ -230,6 +231,31 @@ void GraphicsDevice::setDepthState(const DepthState &depthStencil)
     {
         gl->glDepthFunc(depthStencil.depthCompareFunc);
         lastDepthState.depthCompareFunc = depthStencil.depthCompareFunc;
+    }
+}
+
+void GraphicsDevice::setRasterizerState(const RasterizerState &rasterState)
+{
+    // culling
+    if (lastRasterState.cullMode != rasterState.cullMode) {
+        if (rasterState.cullMode == CullMode::None)
+            gl->glDisable(GL_CULL_FACE);
+        else {
+            gl->glEnable(GL_CULL_FACE);
+
+            if (rasterState.cullMode == CullMode::CullClockwise)
+                gl->glFrontFace(GL_CW);
+            else
+                gl->glFrontFace(GL_CCW);
+        }
+
+        lastRasterState.cullMode = rasterState.cullMode;
+    }
+
+    // polygon fill
+    if (lastRasterState.fillMode != rasterState.fillMode) {
+        gl->glPolygonMode(GL_FRONT_AND_BACK, rasterState.fillMode);
+        lastRasterState.fillMode = rasterState.fillMode;
     }
 }
 

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -48,6 +48,9 @@ GraphicsDevice::GraphicsDevice()
         textureUnits.append(TexturePtr());
 
     gl->glGenVertexArrays(1, &defautVAO);
+
+    //set default blend state
+    this->setBlendState(BlendState::Opaque);
 }
 
 void GraphicsDevice::setViewport(const QRect& vp)

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -158,6 +158,49 @@ void GraphicsDevice::setVertexBuffer(VertexBufferPtr vertexBuffer)
     vertexBuffers.append(vertexBuffer);
 }
 
+void GraphicsDevice::setBlendState(const BlendState &blendState)
+{
+    bool blendEnabled = true;
+    if(blendState.colorSourceBlend == GL_ONE &&
+       blendState.colorDestBlend == GL_ZERO &&
+       blendState.alphaSourceBlend == GL_ONE &&
+       blendState.alphaDestBlend == GL_ZERO) {
+        blendEnabled = false;
+    }
+
+    this->lastBlendEnabled = blendEnabled;
+    if (blendEnabled)
+        gl->glEnable(GL_BLEND);
+    else
+        gl->glDisable(GL_BLEND);
+
+    // update blend equations
+    if (lastBlendState.alphaBlendEquation != blendState.alphaBlendEquation ||
+        lastBlendState.colorBlendEquation != blendState.colorBlendEquation) {
+
+        gl->glBlendEquationSeparate(blendState.colorBlendEquation, blendState.alphaBlendEquation);
+        lastBlendState.alphaBlendEquation = blendState.alphaBlendEquation;
+        lastBlendState.colorBlendEquation = blendState.colorBlendEquation;
+    }
+
+    // update blend functions
+    if(lastBlendState.colorSourceBlend != blendState.colorSourceBlend ||
+       lastBlendState.colorDestBlend != blendState.colorDestBlend ||
+       lastBlendState.alphaSourceBlend != blendState.alphaSourceBlend ||
+       lastBlendState.alphaDestBlend != blendState.alphaDestBlend)
+    {
+        gl->glBlendFuncSeparate(blendState.colorSourceBlend,
+                                blendState.colorDestBlend,
+                                blendState.alphaSourceBlend,
+                                blendState.alphaDestBlend);
+
+        lastBlendState.colorSourceBlend = blendState.colorSourceBlend;
+        lastBlendState.colorDestBlend = blendState.colorDestBlend;
+        lastBlendState.alphaSourceBlend = blendState.alphaSourceBlend;
+        lastBlendState.alphaDestBlend = blendState.alphaDestBlend;
+    }
+}
+
 void GraphicsDevice::drawPrimitives(GLenum primitiveType, int start, int count)
 {
     gl->glBindVertexArray(defautVAO);

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -1,0 +1,99 @@
+#include <QColor>
+
+#include "graphicsdevice.h"
+#include "rendertarget.h"
+#include "texture2d.h"
+
+namespace iris
+{
+
+GraphicsDevice::GraphicsDevice()
+{
+    context = QOpenGLContext::currentContext();
+    gl = context->versionFunctions<QOpenGLFunctions_3_2_Core>();
+
+    // 8 texture units by default
+    for(int i =0;i<8;i++)
+        textureUnits.append(TexturePtr());
+}
+
+void GraphicsDevice::setRenderTarget(RenderTargetPtr renderTarget)
+{
+    clearRenderTarget();
+
+    activeRT = renderTarget;
+    activeRT->bind();
+}
+
+// the size of all the textures should be the same
+void GraphicsDevice::setRenderTarget(QList<Texture2DPtr> colorTargets, Texture2DPtr depthTarget)
+{
+    clearRenderTarget();
+
+    // set the initial size
+    if(colorTargets.size()!=0) {
+        auto tex = colorTargets[0];
+        _internalRT->resize(tex->getWidth(), tex->getHeight(), false);
+    }
+    else if(!!depthTarget) {
+        // set the rt size to the depth target size
+        _internalRT->resize(depthTarget->getWidth(), depthTarget->getHeight(), false);
+    }
+
+    if(colorTargets.size()>0) {
+        for(auto tex : colorTargets)
+            _internalRT->addTexture(tex);
+    }
+
+    if(!!depthTarget)
+        _internalRT->setDepthTexture(depthTarget);
+
+    activeRT = _internalRT;
+    activeRT->bind();
+}
+
+void GraphicsDevice::clearRenderTarget()
+{
+    // reset to default rt
+    gl->glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    if (!!activeRT) {
+        // clear all textures from internal RT
+        if (activeRT == _internalRT) {
+            _internalRT->clearTextures();
+            _internalRT->clearDepthTexture();
+        }
+
+        activeRT.reset();
+    }
+}
+
+void GraphicsDevice::clear(GLuint bits)
+{
+    gl->glClear(bits);
+}
+
+void GraphicsDevice::clear(GLuint bits, QColor color, float depth, int stencil)
+{
+    glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    glClearDepth(depth);
+    glClearStencil(stencil);
+    gl->glClear(bits);
+}
+
+void GraphicsDevice::setTexture(int target, Texture2DPtr texture)
+{
+    gl->glActiveTexture(GL_TEXTURE0+target);
+    gl->glBindTexture(GL_TEXTURE_2D, texture->getTextureId());
+    gl->glActiveTexture(GL_TEXTURE0);
+}
+
+void GraphicsDevice::clearTexture(int target)
+{
+    gl->glActiveTexture(GL_TEXTURE0+target);
+    gl->glBindTexture(GL_TEXTURE_2D, 0);
+    gl->glActiveTexture(GL_TEXTURE0);
+}
+
+
+
+}

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -128,9 +128,9 @@ void GraphicsDevice::clear(GLuint bits)
 
 void GraphicsDevice::clear(GLuint bits, QColor color, float depth, int stencil)
 {
-    glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
-    glClearDepth(depth);
-    glClearStencil(stencil);
+    gl->glClearColor(color.redF(), color.greenF(), color.blueF(), color.alphaF());
+    gl->glClearDepth(depth);
+    gl->glClearStencil(stencil);
     gl->glClear(bits);
 }
 

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -49,8 +49,9 @@ GraphicsDevice::GraphicsDevice()
 
     gl->glGenVertexArrays(1, &defautVAO);
 
-    //set default blend state
+    //set default blend and depth state
     this->setBlendState(BlendState::Opaque);
+    this->setDepthState(DepthState::Default);
 }
 
 void GraphicsDevice::setViewport(const QRect& vp)
@@ -201,6 +202,34 @@ void GraphicsDevice::setBlendState(const BlendState &blendState)
         lastBlendState.colorDestBlend = blendState.colorDestBlend;
         lastBlendState.alphaSourceBlend = blendState.alphaSourceBlend;
         lastBlendState.alphaDestBlend = blendState.alphaDestBlend;
+    }
+}
+
+void GraphicsDevice::setDepthState(const DepthState &depthStencil)
+{
+    // depth test
+    if (lastDepthState.depthBufferEnabled != depthStencil.depthBufferEnabled)
+    {
+        if (depthStencil.depthBufferEnabled)
+            gl->glEnable(GL_DEPTH_TEST);
+        else
+            gl->glDisable(GL_DEPTH_TEST);
+
+        lastDepthState.depthBufferEnabled = depthStencil.depthBufferEnabled;
+    }
+
+    // depth write
+    if (lastDepthState.depthWriteEnabled != depthStencil.depthWriteEnabled)
+    {
+        gl->glDepthMask(depthStencil.depthWriteEnabled);
+        lastDepthState.depthWriteEnabled = depthStencil.depthWriteEnabled;
+    }
+
+    // depth func
+    if (lastDepthState.depthCompareFunc != depthStencil.depthCompareFunc)
+    {
+        gl->glDepthFunc(depthStencil.depthCompareFunc);
+        lastDepthState.depthCompareFunc = depthStencil.depthCompareFunc;
     }
 }
 

--- a/src/irisgl/src/graphics/graphicsdevice.cpp
+++ b/src/irisgl/src/graphics/graphicsdevice.cpp
@@ -30,6 +30,11 @@ QOpenGLFunctions_3_2_Core *GraphicsDevice::getGL() const
     return gl;
 }
 
+GraphicsDevicePtr GraphicsDevice::create()
+{
+    return GraphicsDevicePtr(new GraphicsDevice());
+}
+
 GraphicsDevice::GraphicsDevice()
 {
     context = QOpenGLContext::currentContext();
@@ -88,6 +93,11 @@ void GraphicsDevice::clearRenderTarget()
 
         activeRT.reset();
     }
+}
+
+void GraphicsDevice::clear(QColor color)
+{
+    clear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT|GL_STENCIL_BUFFER_BIT, color);
 }
 
 void GraphicsDevice::clear(GLuint bits)

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -24,11 +24,16 @@ class VertexBuffer
     friend class GraphicsDevice;
 public:
     void* data;
+    int dataSize;
+
     GLuint bufferId;
     VertexLayout vertexLayout;
     GraphicsDevicePtr device;
 
-    VertexBuffer(GraphicsDevicePtr device, VertexLayout vertexLayout);
+    static VertexBufferPtr create(GraphicsDevicePtr device, VertexLayout vertexLayout)
+    {
+        return VertexBufferPtr(new VertexBuffer(device, vertexLayout));
+    }
 
     template<typename T>
     void setData(T* data, unsigned int sizeInBytes)
@@ -37,6 +42,9 @@ public:
     }
 
     void setData(void* data, unsigned int sizeinBytes);
+
+private:
+    VertexBuffer(GraphicsDevicePtr device, VertexLayout vertexLayout);
 };
 
 class IndexBuffer
@@ -61,13 +69,25 @@ class GraphicsDevice
     QOpenGLFunctions_3_2_Core* gl;
     QOpenGLContext* context;
 
-    QStack<QRect> viewportStack;
+    QRect viewport;
     RenderTargetPtr _internalRT;
     RenderTargetPtr activeRT;
 
-    QList<TexturePtr> textureUnits;
+    QVector<TexturePtr> textureUnits;
+    QVector<VertexBufferPtr> vertexBuffers;
+    IndexBufferPtr indexBuffers;
+
+    // apparently gl needs at least one to be set
+    // before you can render
+    GLuint defautVAO;
+
+    ShaderPtr activeShader;
+
 public:
     GraphicsDevice();
+
+    void setViewport(const QRect& vp);
+    QRect getViewport();
 
     void setRenderTarget(RenderTargetPtr renderTarget);
     void setRenderTarget(QList<Texture2DPtr> colorTargets, Texture2DPtr depthTarget);

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -8,6 +8,7 @@
 #include "vertexlayout.h"
 #include "blendstate.h"
 #include "depthstate.h"
+#include "rasterizerstate.h"
 
 class QOpenGLContext;
 
@@ -87,8 +88,8 @@ class GraphicsDevice
 
     bool lastBlendEnabled;
     BlendState lastBlendState;
-
     DepthState lastDepthState;
+    RasterizerState lastRasterState;
 
 public:
     GraphicsDevice();
@@ -114,6 +115,7 @@ public:
 
     void setBlendState(const BlendState& blendState);
     void setDepthState(const DepthState& depthStencil);
+    void setRasterizerState(const RasterizerState& rasterState);
 
     void drawPrimitives(GLenum primitiveType,int start, int count);
     QOpenGLFunctions_3_2_Core *getGL() const;

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -7,6 +7,7 @@
 #include <QStack>
 #include "vertexlayout.h"
 #include "blendstate.h"
+#include "depthstate.h"
 
 class QOpenGLContext;
 
@@ -79,13 +80,15 @@ class GraphicsDevice
     IndexBufferPtr indexBuffers;
 
     // apparently gl needs at least one to be set
-    // before you can render
+    // before you can render anything
     GLuint defautVAO;
 
     ShaderPtr activeShader;
 
     bool lastBlendEnabled;
     BlendState lastBlendState;
+
+    DepthState lastDepthState;
 
 public:
     GraphicsDevice();
@@ -110,6 +113,7 @@ public:
     void setIndexBuffer(IndexBufferPtr indexBuffer);
 
     void setBlendState(const BlendState& blendState);
+    void setDepthState(const DepthState& depthStencil);
 
     void drawPrimitives(GLenum primitiveType,int start, int count);
     QOpenGLFunctions_3_2_Core *getGL() const;

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -3,17 +3,53 @@
 
 #include "../irisglfwd.h"
 #include <QOpenGLFunctions_3_2_Core>
+#include <QRect>
+#include <QStack>
+#include "vertexlayout.h"
 
 class QOpenGLContext;
 
 namespace iris
 {
 
+class GraphicsDevice;
+typedef QSharedPointer<GraphicsDevice> GraphicsDevicePtr;
+class VertexBuffer;
+typedef QSharedPointer<VertexBuffer> VertexBufferPtr;
+class IndexBuffer;
+typedef QSharedPointer<IndexBuffer> IndexBufferPtr;
+
 class VertexBuffer
+{
+    friend class GraphicsDevice;
+public:
+    void* data;
+    GLuint bufferId;
+    VertexLayout vertexLayout;
+    GraphicsDevicePtr device;
+
+    VertexBuffer(GraphicsDevicePtr device, VertexLayout vertexLayout);
+
+    template<typename T>
+    void setData(T* data, unsigned int sizeInBytes)
+    {
+        setData((void*) data, sizeInBytes);
+    }
+
+    void setData(void* data, unsigned int sizeinBytes);
+};
+
+class IndexBuffer
 {
 public:
     void* data;
     GLuint bufferId;
+
+    template<typename T>
+    void setData(T* data, unsigned int sizeInBytes)
+    {
+        memcpy(this->data, data, sizeInBytes);
+    }
 };
 
 /*
@@ -49,6 +85,7 @@ public:
     void setIndexBuffer(IndexBufferPtr indexBuffer);
 
     void drawPrimitives(GLenum primitiveType,int start, int count);
+    QOpenGLFunctions_3_2_Core *getGL() const;
 };
 
 }

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -6,6 +6,7 @@
 #include <QRect>
 #include <QStack>
 #include "vertexlayout.h"
+#include "blendstate.h"
 
 class QOpenGLContext;
 
@@ -83,6 +84,9 @@ class GraphicsDevice
 
     ShaderPtr activeShader;
 
+    bool latsBlendEnabled;
+    BlendState lastBlendState;
+
 public:
     GraphicsDevice();
 
@@ -104,6 +108,8 @@ public:
     void setVertexBuffer(VertexBufferPtr vertexBuffer);
     void setVertexBuffers(QList<VertexBufferPtr> vertexBuffers);
     void setIndexBuffer(IndexBufferPtr indexBuffer);
+
+    void setBlendState(const BlendState& blendState);
 
     void drawPrimitives(GLenum primitiveType,int start, int count);
     QOpenGLFunctions_3_2_Core *getGL() const;

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -1,0 +1,56 @@
+#ifndef GRAPHICSDEVICE_H
+#define GRAPHICSDEVICE_H
+
+#include "../irisglfwd.h"
+#include <QOpenGLFunctions_3_2_Core>
+
+class QOpenGLContext;
+
+namespace iris
+{
+
+class VertexBuffer
+{
+public:
+    void* data;
+    GLuint bufferId;
+};
+
+/*
+ * This class is intended to wrap all calls to opengl with simpler
+ * and easier-to-use functions
+*/
+class GraphicsDevice
+{
+    QOpenGLFunctions_3_2_Core* gl;
+    QOpenGLContext* context;
+
+    QStack<QRect> viewportStack;
+    RenderTargetPtr _internalRT;
+    RenderTargetPtr activeRT;
+
+    QList<TexturePtr> textureUnits;
+public:
+    GraphicsDevice();
+
+    void setRenderTarget(RenderTargetPtr renderTarget);
+    void setRenderTarget(QList<Texture2DPtr> colorTargets, Texture2DPtr depthTarget);
+    void clearRenderTarget();
+
+    void clear(GLuint bits);
+    void clear(GLuint bits, QColor color, float depth=1.0f, int stencil=0);
+
+    void setShader(ShaderPtr shader);
+    void setTexture(int target, Texture2DPtr texture);
+    void clearTexture(int target);
+
+    void setVertexBuffer(VertexBufferPtr vertexBuffer);
+    void setVertexBuffers(QList<VertexBufferPtr> vertexBuffers);
+    void setIndexBuffer(IndexBufferPtr indexBuffer);
+
+    void drawPrimitives(GLenum primitiveType,int start, int count);
+};
+
+}
+
+#endif // GRAPHICSDEVICE_H

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -113,9 +113,9 @@ public:
     void setVertexBuffers(QList<VertexBufferPtr> vertexBuffers);
     void setIndexBuffer(IndexBufferPtr indexBuffer);
 
-    void setBlendState(const BlendState& blendState);
-    void setDepthState(const DepthState& depthStencil);
-    void setRasterizerState(const RasterizerState& rasterState);
+    void setBlendState(const BlendState& blendState, bool force = false);
+    void setDepthState(const DepthState& depthStencil, bool force = false);
+    void setRasterizerState(const RasterizerState& rasterState, bool force = false);
 
     void drawPrimitives(GLenum primitiveType,int start, int count);
     QOpenGLFunctions_3_2_Core *getGL() const;

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -84,7 +84,7 @@ class GraphicsDevice
 
     ShaderPtr activeShader;
 
-    bool latsBlendEnabled;
+    bool lastBlendEnabled;
     BlendState lastBlendState;
 
 public:

--- a/src/irisgl/src/graphics/graphicsdevice.h
+++ b/src/irisgl/src/graphics/graphicsdevice.h
@@ -73,6 +73,7 @@ public:
     void setRenderTarget(QList<Texture2DPtr> colorTargets, Texture2DPtr depthTarget);
     void clearRenderTarget();
 
+    void clear(QColor color);
     void clear(GLuint bits);
     void clear(GLuint bits, QColor color, float depth=1.0f, int stencil=0);
 
@@ -86,6 +87,8 @@ public:
 
     void drawPrimitives(GLenum primitiveType,int start, int count);
     QOpenGLFunctions_3_2_Core *getGL() const;
+
+    static GraphicsDevicePtr create();
 };
 
 }

--- a/src/irisgl/src/graphics/graphicshelper.cpp
+++ b/src/irisgl/src/graphics/graphicshelper.cpp
@@ -42,6 +42,7 @@ QOpenGLShaderProgram* GraphicsHelper::loadShader(QString vsPath,QString fsPath)
     program->addShader(fshader);
 
     program->bindAttributeLocation("a_pos",(int)VertexAttribUsage::Position);
+    program->bindAttributeLocation("a_color",(int)VertexAttribUsage::Color);
     program->bindAttributeLocation("a_texCoord",(int)VertexAttribUsage::TexCoord0);
     program->bindAttributeLocation("a_texCoord1",(int)VertexAttribUsage::TexCoord1);
     program->bindAttributeLocation("a_texCoord2",(int)VertexAttribUsage::TexCoord2);

--- a/src/irisgl/src/graphics/mesh.h
+++ b/src/irisgl/src/graphics/mesh.h
@@ -34,16 +34,17 @@ class BoundingSphere;
 enum class VertexAttribUsage : int
 {
     Position = 0,
-    TexCoord0 = 1,
-    TexCoord1 = 2,
-    TexCoord2 = 3,
-    TexCoord3 = 4,
-    Normal = 5,
-    Tangent = 6,
-    BiTangent = 7,
-    BoneIndices = 8,
-    BoneWeights = 9,
-    Count = 10
+    Color = 1,
+    TexCoord0 = 2,
+    TexCoord1 = 3,
+    TexCoord2 = 4,
+    TexCoord3 = 5,
+    Normal = 6,
+    Tangent = 7,
+    BiTangent = 8,
+    BoneIndices = 9,
+    BoneWeights = 10,
+    Count = 11
 };
 
 struct MeshMaterialData

--- a/src/irisgl/src/graphics/rasterizerstate.cpp
+++ b/src/irisgl/src/graphics/rasterizerstate.cpp
@@ -5,6 +5,6 @@ namespace iris
 
 RasterizerState RasterizerState::CullCounterClockwise = RasterizerState(CullMode::CullCounterClockwise, GL_FILL);
 RasterizerState RasterizerState::CullClockwise = RasterizerState(CullMode::CullClockwise, GL_FILL);
-RasterizerState RasterizerState::CullNone = RasterizerState();
+RasterizerState RasterizerState::CullNone = RasterizerState(CullMode::None, GL_FILL);
 
 }

--- a/src/irisgl/src/graphics/rasterizerstate.cpp
+++ b/src/irisgl/src/graphics/rasterizerstate.cpp
@@ -1,0 +1,10 @@
+#include "rasterizerstate.h"
+
+namespace iris
+{
+
+RasterizerState RasterizerState::CullCounterClockwise = RasterizerState(CullMode::CullCounterClockwise, GL_FILL);
+RasterizerState RasterizerState::CullClockwise = RasterizerState(CullMode::CullClockwise, GL_FILL);
+RasterizerState RasterizerState::CullNone = RasterizerState();
+
+}

--- a/src/irisgl/src/graphics/rasterizerstate.h
+++ b/src/irisgl/src/graphics/rasterizerstate.h
@@ -1,0 +1,40 @@
+#ifndef RASTERIZERSTATE_H
+#define RASTERIZERSTATE_H
+
+#include <qopengl.h>
+
+namespace iris
+{
+
+enum class CullMode
+{
+    None,
+    CullClockwise,
+    CullCounterClockwise
+};
+
+struct RasterizerState
+{
+    CullMode cullMode;
+    GLenum fillMode;
+
+    RasterizerState()
+    {
+        cullMode= CullMode::CullCounterClockwise;
+        fillMode = GL_FILL;
+    }
+
+    RasterizerState(CullMode cullMode, GLenum fillMode):
+        cullMode(cullMode),
+        fillMode(fillMode)
+    {
+    }
+
+    static RasterizerState CullCounterClockwise;
+    static RasterizerState CullClockwise;
+    static RasterizerState CullNone;
+};
+
+}
+
+#endif // RASTERIZERSTATE_H

--- a/src/irisgl/src/graphics/rendertarget.cpp
+++ b/src/irisgl/src/graphics/rendertarget.cpp
@@ -114,11 +114,18 @@ void RenderTarget::resize(int width, int height, bool resizeTextures)
 
 void RenderTarget::addTexture(Texture2DPtr tex)
 {
+    Q_ASSERT_X(width==tex->getWidth() && height==tex->getHeight(),
+               "RenderTarget",
+               "Size of attached texture should be the same as size of render target");
     textures.append(tex);
 }
 
 void RenderTarget::setDepthTexture(Texture2DPtr depthTex)
 {
+    Q_ASSERT_X(width==depthTex->getWidth() && height==depthTex->getHeight(),
+               "RenderTarget",
+               "Size of attached depth texture should be the same as size of render target");
+
     clearRenderBuffer();
     depthTexture = depthTex;
 }

--- a/src/irisgl/src/graphics/rendertarget.cpp
+++ b/src/irisgl/src/graphics/rendertarget.cpp
@@ -135,6 +135,11 @@ void RenderTarget::clearTextures()
     textures.clear();
 }
 
+void RenderTarget::clearDepthTexture()
+{
+    depthTexture.reset();
+}
+
 void RenderTarget::clearRenderBuffer()
 {
     gl->glBindFramebuffer(GL_FRAMEBUFFER, fboId);

--- a/src/irisgl/src/graphics/rendertarget.cpp
+++ b/src/irisgl/src/graphics/rendertarget.cpp
@@ -114,9 +114,13 @@ void RenderTarget::resize(int width, int height, bool resizeTextures)
 
 void RenderTarget::addTexture(Texture2DPtr tex)
 {
-    Q_ASSERT_X(width==tex->getWidth() && height==tex->getHeight(),
+    if (textures.count()!=0) {
+        // this assertion should only hold true if this isnt the first texture
+        Q_ASSERT_X(width==tex->getWidth() && height==tex->getHeight(),
                "RenderTarget",
                "Size of attached texture should be the same as size of render target");
+    }
+
     textures.append(tex);
 }
 

--- a/src/irisgl/src/graphics/rendertarget.cpp
+++ b/src/irisgl/src/graphics/rendertarget.cpp
@@ -95,6 +95,9 @@ void RenderTarget::checkStatus()
 
 void RenderTarget::resize(int width, int height, bool resizeTextures)
 {
+    if (this->width == width && this->height == height)
+        return;
+
     this->width = width;
     this->height = height;
 

--- a/src/irisgl/src/graphics/shader.cpp
+++ b/src/irisgl/src/graphics/shader.cpp
@@ -77,6 +77,7 @@ Shader::Shader(QOpenGLFunctions_3_2_Core* gl,QString vertexShader,QString fragme
     program->addShader(fshader);
 
     program->bindAttributeLocation("a_pos",(int)VertexAttribUsage::Position);
+    program->bindAttributeLocation("a_color",(int)VertexAttribUsage::Color);
     program->bindAttributeLocation("a_texCoord",(int)VertexAttribUsage::TexCoord0);
     program->bindAttributeLocation("a_texCoord1",(int)VertexAttribUsage::TexCoord1);
     program->bindAttributeLocation("a_texCoord2",(int)VertexAttribUsage::TexCoord2);

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -2,6 +2,7 @@
 #include "graphicsdevice.h"
 #include "shader.h"
 #include "texture2d.h"
+#include "font.h"
 #include <QVector>
 #include <QMatrix4x4>
 #include <QOpenGLShaderProgram>
@@ -62,6 +63,19 @@ void SpriteBatch::draw(Texture2DPtr texture, QVector2D pos, QColor color)
                   0);
 }
 
+void SpriteBatch::drawString(FontPtr font, QString text, QVector2D pos, QColor color)
+{
+    int advance = 0;
+    int spacing = 0;
+    for(auto chr : text) {
+        auto& glyph = font->glyphs[chr];
+        draw(glyph.tex, pos, color);
+
+        //advance += glyph.width + spacing;
+        pos.setX(pos.x() + glyph.width + spacing);
+    }
+}
+
 void SpriteBatch::end()
 {
     int vertexCount = 0;
@@ -74,6 +88,7 @@ void SpriteBatch::end()
     gl->glDisable(GL_CULL_FACE);
     gl->glEnable(GL_BLEND);
     gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
+    gl->glBlendFunc(GL_ONE,GL_ONE); // works well with fonts
 
     // build vbo and submit
     while(items.size()>0) {

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -46,6 +46,7 @@ void SpriteBatch::begin()
     auto rect = graphics->getViewport();
     proj.setToIdentity();
     proj.ortho(0, rect.width(),rect.height(), 0, -10, 10);
+    //proj.ortho(0, 500, 0, 300, -10, 10);
 
     spriteShader->program->setUniformValue("u_viewMatrix", view);
     spriteShader->program->setUniformValue("u_projMatrix", proj);
@@ -86,9 +87,11 @@ void SpriteBatch::end()
 
     // testing
     auto gl = graphics->getGL();
-    graphics->setRasterizerState(RasterizerState::CullClockwise);
+    graphics->setRasterizerState(RasterizerState::CullNone);
     graphics->setDepthState(DepthState::None);
     graphics->setBlendState(BlendState::AlphaBlend);
+
+    graphics->setShader(spriteShader);
 
     // build vbo and submit
     while(items.size()>0) {

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -3,6 +3,7 @@
 #include "shader.h"
 #include "texture2d.h"
 #include "font.h"
+#include "blendstate.h"
 #include <QVector>
 #include <QMatrix4x4>
 #include <QOpenGLShaderProgram>
@@ -86,10 +87,10 @@ void SpriteBatch::end()
     // testing
     auto gl = graphics->getGL();
     gl->glDisable(GL_CULL_FACE);
-    gl->glEnable(GL_BLEND);
     gl->glDisable(GL_DEPTH_TEST);
-    gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
-    //gl->glBlendFunc(GL_ONE,GL_ONE); // works well with fonts
+    //gl->glEnable(GL_BLEND);
+    //gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
+    graphics->setBlendState(BlendState::AlphaBlend);
 
     // build vbo and submit
     while(items.size()>0) {

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -73,6 +73,7 @@ void SpriteBatch::end()
     auto gl = graphics->getGL();
     gl->glDisable(GL_CULL_FACE);
     gl->glEnable(GL_BLEND);
+    gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
 
     // build vbo and submit
     while(items.size()>0) {

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -1,0 +1,165 @@
+#include "spritebatch.h"
+#include "graphicsdevice.h"
+#include "shader.h"
+#include "texture2d.h"
+#include <QVector>
+#include <QMatrix4x4>
+#include <QOpenGLShaderProgram>
+
+namespace iris
+{
+
+SpriteBatch::SpriteBatch(GraphicsDevicePtr graphicsDevice)
+{
+    graphics = graphicsDevice;
+    spriteShader = Shader::load(graphics->getGL(),
+                          ":/assets/shaders/sprite.vert",
+                          ":/assets/shaders/sprite.frag");
+
+    // preallocate batches
+    for(auto i=0;i<100;i++)
+        _pool.append(new SpriteBatchItem());
+
+    VertexLayout layout;
+    layout.addAttrib(VertexAttribUsage::Position, GL_FLOAT, 3, sizeof(float)*3);
+    layout.addAttrib(VertexAttribUsage::Color, GL_FLOAT, 4, sizeof(float)*4);
+    layout.addAttrib(VertexAttribUsage::TexCoord0, GL_FLOAT, 2, sizeof(float)*2);
+    vertexBuffer = VertexBuffer::create(graphicsDevice, layout);
+
+    data.reserve(_pool.size() * layout.getStride());
+}
+
+SpriteBatchPtr SpriteBatch::create(GraphicsDevicePtr graphicsDevice)
+{
+    return SpriteBatchPtr(new SpriteBatch(graphicsDevice));
+}
+
+void SpriteBatch::begin()
+{
+    graphics->setShader(spriteShader);
+    QMatrix4x4 view;
+    view.setToIdentity();
+
+    QMatrix4x4 proj;
+    auto rect = graphics->getViewport();
+    proj.setToIdentity();
+    proj.ortho(0, rect.width(),rect.height(), 0, -10, 10);
+
+    spriteShader->program->setUniformValue("u_viewMatrix", view);
+    spriteShader->program->setUniformValue("u_projMatrix", proj);
+
+}
+
+void SpriteBatch::draw(Texture2DPtr texture, QVector2D pos, QColor color)
+{
+    auto item = addItem();
+    item->tex = texture;
+
+    item->setData(pos.x(), pos.y(),
+                  texture->getWidth(), texture->getHeight(),
+                  color,
+                  QVector2D(0,0), QVector2D(1,1),
+                  0);
+}
+
+void SpriteBatch::end()
+{
+    int vertexCount = 0;
+    int startIndex = 0;
+    Texture2DPtr lastTex;
+    data.clear();
+
+    // testing
+    auto gl = graphics->getGL();
+    gl->glDisable(GL_CULL_FACE);
+    gl->glEnable(GL_BLEND);
+
+    // build vbo and submit
+    while(items.size()>0) {
+        auto item = items.takeFirst();
+
+        if(lastTex != item->tex) {
+            // batch has ended, draw sprites
+            graphics->setTexture(0, lastTex);
+
+            vertexBuffer->setData(data.data(), data.size()*sizeof(float));//slow to do for each sprite, fix!
+            graphics->setVertexBuffer(vertexBuffer);
+            graphics->drawPrimitives(GL_TRIANGLES, startIndex, vertexCount);
+
+            startIndex += vertexCount;
+            vertexCount = 0;
+            lastTex = item->tex;
+        }
+
+        // triangle 1
+        addVertexToData(item->vertTL);
+        addVertexToData(item->vertTR);
+        addVertexToData(item->vertBL);
+        vertexCount+=3;
+
+        // triangle 2
+        addVertexToData(item->vertTR);
+        addVertexToData(item->vertBR);
+        addVertexToData(item->vertBL);
+        vertexCount+=3;
+
+        // return to pool
+        _pool.append(item);
+    }
+
+    // draw remaining
+    graphics->setTexture(0, lastTex);
+    vertexBuffer->setData(data.data(), data.size()*sizeof(float));//slow to do for each sprite, fix!
+    graphics->setVertexBuffer(vertexBuffer);
+    graphics->drawPrimitives(GL_TRIANGLES, startIndex, vertexCount);
+
+}
+
+SpriteBatchItem *SpriteBatch::addItem()
+{
+    SpriteBatchItem* item;
+    if(_pool.size() > 0) {
+        item = _pool.takeLast();
+    } else {
+        item = new SpriteBatchItem();
+    }
+
+    items.append(item);
+
+    return item;
+}
+
+void SpriteBatch::addVertexToData(SpriteBatchVertex &vertex)
+{
+    data.append(vertex.pos.x()); data.append(vertex.pos.y()); data.append(vertex.pos.z());
+    data.append(vertex.color.redF()); data.append(vertex.color.greenF()); data.append(vertex.color.blueF()); data.append(vertex.color.alphaF());
+    data.append(vertex.texCoord.x()); data.append(vertex.texCoord.y());
+}
+
+void SpriteBatchItem::setData(float x, float y, float dx, float dy, float w, float h, float sin, float cos, QColor color, QVector2D texCoordTl, QVector2D texCoordBR, float depth)
+{
+    Q_ASSERT_X(false,"SpriteBatch","Not implemented");
+}
+
+void SpriteBatchItem::setData(float x, float y, float w, float h, QColor color, QVector2D texCoordTL, QVector2D texCoordBR, float depth)
+{
+    vertTL.pos = QVector3D(x, y, depth);
+    vertTL.color = color;
+    vertTL.texCoord = QVector2D(texCoordTL.x(), texCoordTL.y());
+
+    vertTR.pos = QVector3D(x + w, y, depth);
+    vertTR.color = color;
+    vertTR.texCoord = QVector2D(texCoordBR.x(), texCoordTL.y());
+
+    vertBL.pos = QVector3D(x, y + h, depth);
+    vertBL.color = color;
+    vertBL.texCoord = QVector2D(texCoordTL.x(), texCoordBR.y());
+
+    vertBR.pos = QVector3D(x + w, y + h, depth);
+    vertBR.color = color;
+    vertBR.texCoord = QVector2D(texCoordBR.x(), texCoordBR.y());
+}
+
+
+
+}

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -87,6 +87,7 @@ void SpriteBatch::end()
     auto gl = graphics->getGL();
     gl->glDisable(GL_CULL_FACE);
     gl->glEnable(GL_BLEND);
+    gl->glDisable(GL_DEPTH_TEST);
     gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
     //gl->glBlendFunc(GL_ONE,GL_ONE); // works well with fonts
 

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -88,7 +88,7 @@ void SpriteBatch::end()
     gl->glDisable(GL_CULL_FACE);
     gl->glEnable(GL_BLEND);
     gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
-    gl->glBlendFunc(GL_ONE,GL_ONE); // works well with fonts
+    //gl->glBlendFunc(GL_ONE,GL_ONE); // works well with fonts
 
     // build vbo and submit
     while(items.size()>0) {

--- a/src/irisgl/src/graphics/spritebatch.cpp
+++ b/src/irisgl/src/graphics/spritebatch.cpp
@@ -86,10 +86,8 @@ void SpriteBatch::end()
 
     // testing
     auto gl = graphics->getGL();
-    gl->glDisable(GL_CULL_FACE);
-    gl->glDisable(GL_DEPTH_TEST);
-    //gl->glEnable(GL_BLEND);
-    //gl->glBlendFunc(GL_SRC_ALPHA,GL_ONE_MINUS_SRC_ALPHA);
+    graphics->setRasterizerState(RasterizerState::CullClockwise);
+    graphics->setDepthState(DepthState::None);
     graphics->setBlendState(BlendState::AlphaBlend);
 
     // build vbo and submit

--- a/src/irisgl/src/graphics/spritebatch.h
+++ b/src/irisgl/src/graphics/spritebatch.h
@@ -1,0 +1,65 @@
+#ifndef SPRITEBATCH_H
+#define SPRITEBATCH_H
+
+#include "../irisglfwd.h"
+#include <QVector>
+#include <QVector3D>
+#include <QVector2D>
+#include <QColor>
+
+namespace iris
+{
+
+struct SpriteBatchVertex
+{
+    QVector3D pos;
+    QVector2D texCoord;
+    QColor color;
+};
+
+struct SpriteBatchItem
+{
+    Texture2DPtr tex;
+    float sortKey;
+
+    SpriteBatchVertex vertTL;
+    SpriteBatchVertex vertTR;
+    SpriteBatchVertex vertBL;
+    SpriteBatchVertex vertBR;
+
+    void setData(float x, float y, float dx, float dy,
+                 float w, float h, float sin, float cos,
+                 QColor color, QVector2D texCoordTl, QVector2D texCoordBR, float depth);
+
+    void setData(float x, float y, float w, float h,
+                 QColor color, QVector2D texCoordTl, QVector2D texCoordBR, float depth);
+};
+
+class SpriteBatch
+{
+public:
+    static SpriteBatchPtr create(GraphicsDevicePtr graphicsDevice);
+
+    void begin();
+    void draw(Texture2DPtr texture, QRect rect, QColor color);
+    void draw(Texture2DPtr texture, QVector2D rect, QColor color);
+    void end();
+
+private:
+    SpriteBatch(GraphicsDevicePtr graphicsDevice);
+    SpriteBatchItem* addItem();
+    void addVertexToData(SpriteBatchVertex& vertex);
+
+    QVector<SpriteBatchItem*> items;
+    QVector<SpriteBatchItem*> _pool;
+
+    VertexBufferPtr vertexBuffer;
+    QVector<float> data;
+
+    ShaderPtr spriteShader;
+    GraphicsDevicePtr graphics;
+};
+
+}
+
+#endif // SPRITEBATCH_H

--- a/src/irisgl/src/graphics/spritebatch.h
+++ b/src/irisgl/src/graphics/spritebatch.h
@@ -42,7 +42,8 @@ public:
 
     void begin();
     void draw(Texture2DPtr texture, QRect rect, QColor color);
-    void draw(Texture2DPtr texture, QVector2D rect, QColor color);
+    void draw(Texture2DPtr texture, QVector2D pos, QColor color);
+    void drawString(FontPtr font, QString text, QVector2D pos, QColor color);
     void end();
 
 private:

--- a/src/irisgl/src/graphics/texture2d.cpp
+++ b/src/irisgl/src/graphics/texture2d.cpp
@@ -166,4 +166,19 @@ int Texture2D::getHeight()
     return texture->height();
 }
 
+void Texture2D::setFilters(QOpenGLTexture::Filter minFilter, QOpenGLTexture::Filter magFilter)
+{
+    texture->bind();
+    texture->setMinMagFilters(minFilter, magFilter);
+    texture->release();
+}
+
+void Texture2D::setWrapMode(QOpenGLTexture::WrapMode wrapS, QOpenGLTexture::WrapMode wrapT)
+{
+    texture->bind();
+    texture->setWrapMode(QOpenGLTexture::DirectionS, wrapS);
+    texture->setWrapMode(QOpenGLTexture::DirectionT, wrapT);
+    texture->release();
+}
+
 }

--- a/src/irisgl/src/graphics/texture2d.cpp
+++ b/src/irisgl/src/graphics/texture2d.cpp
@@ -156,5 +156,14 @@ Texture2D::Texture2D(QOpenGLTexture *tex)
     gl = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_2_Core>();
 }
 
+int Texture2D::getWidth()
+{
+    return texture->width();
+}
+
+int Texture2D::getHeight()
+{
+    return texture->height();
+}
 
 }

--- a/src/irisgl/src/graphics/texture2d.cpp
+++ b/src/irisgl/src/graphics/texture2d.cpp
@@ -133,6 +133,9 @@ Texture2DPtr Texture2D::create(int width, int height,QOpenGLTexture::TextureForm
 
 void Texture2D::resize(int width, int height)
 {
+    if(texture->width() == width && texture->height() == height)
+        return;
+
     auto texFormat = texture->format();
     auto minFilter = texture->minificationFilter();
     auto magFilter = texture->magnificationFilter();

--- a/src/irisgl/src/graphics/texture2d.h
+++ b/src/irisgl/src/graphics/texture2d.h
@@ -79,6 +79,9 @@ public:
 
     QPixmap readData();
 
+    int getWidth();
+    int getHeight();
+
 private:
     Texture2D(QOpenGLTexture* tex);
 

--- a/src/irisgl/src/graphics/texture2d.h
+++ b/src/irisgl/src/graphics/texture2d.h
@@ -82,6 +82,9 @@ public:
     int getWidth();
     int getHeight();
 
+    void setFilters(QOpenGLTexture::Filter minFilter, QOpenGLTexture::Filter magFilter);
+    void setWrapMode(QOpenGLTexture::WrapMode wrapS, QOpenGLTexture::WrapMode wrapT);
+
 private:
     Texture2D(QOpenGLTexture* tex);
 

--- a/src/irisgl/src/graphics/vertexlayout.cpp
+++ b/src/irisgl/src/graphics/vertexlayout.cpp
@@ -30,6 +30,11 @@ void VertexLayout::addAttrib(VertexAttribUsage usage,int type,int count,int size
     stride += sizeOfAttribInBytes;
 }
 
+int VertexLayout::getStride()
+{
+    return stride;
+}
+
 // https://stackoverflow.com/a/30106751
 #define BUFFER_OFFSET(i) ((char*)nullptr+(i))
 

--- a/src/irisgl/src/graphics/vertexlayout.h
+++ b/src/irisgl/src/graphics/vertexlayout.h
@@ -42,6 +42,8 @@ public:
 
     void addAttrib(VertexAttribUsage usage, int type, int count, int sizeInBytes);
 
+    int getStride();
+
     //todo: make this more efficient
     void bind();
     void unbind();

--- a/src/irisgl/src/irisglfwd.h
+++ b/src/irisgl/src/irisglfwd.h
@@ -73,6 +73,7 @@ class BoundingSphere;
 class VertexBuffer;
 class IndexBuffer;
 class GraphicsDevice;
+class ContentManager;
 class SpriteBatch;
 class Font;
 
@@ -105,6 +106,7 @@ typedef QSharedPointer<SkeletalAnimation> SkeletalAnimationPtr;
 typedef QSharedPointer<VertexBuffer> VertexBufferPtr;
 typedef QSharedPointer<IndexBuffer> IndexBufferPtr;
 typedef QSharedPointer<GraphicsDevice> GraphicsDevicePtr;
+typedef QSharedPointer<ContentManager> ContentManagerPtr;
 typedef QSharedPointer<SpriteBatch> SpriteBatchPtr;
 typedef QSharedPointer<Font> FontPtr;
 

--- a/src/irisgl/src/irisglfwd.h
+++ b/src/irisgl/src/irisglfwd.h
@@ -70,6 +70,10 @@ class SkeletalAnimation;
 template<typename T> class Key;
 typedef Key<float> FloatKey;
 class BoundingSphere;
+class VertexBuffer;
+class IndexBuffer;
+class GraphicsDevice;
+class SpriteBatch;
 
 typedef QSharedPointer<iris::Animation> AnimationPtr;
 typedef QSharedPointer<Shader> ShaderPtr;
@@ -97,6 +101,10 @@ typedef QSharedPointer<PostProcessManager> PostProcessManagerPtr;
 typedef QSharedPointer<Bone> BonePtr;
 typedef QSharedPointer<Skeleton> SkeletonPtr;
 typedef QSharedPointer<SkeletalAnimation> SkeletalAnimationPtr;
+typedef QSharedPointer<VertexBuffer> VertexBufferPtr;
+typedef QSharedPointer<IndexBuffer> IndexBufferPtr;
+typedef QSharedPointer<GraphicsDevice> GraphicsDevicePtr;
+typedef QSharedPointer<SpriteBatch> SpriteBatchPtr;
 
 
 

--- a/src/irisgl/src/irisglfwd.h
+++ b/src/irisgl/src/irisglfwd.h
@@ -74,6 +74,7 @@ class VertexBuffer;
 class IndexBuffer;
 class GraphicsDevice;
 class SpriteBatch;
+class Font;
 
 typedef QSharedPointer<iris::Animation> AnimationPtr;
 typedef QSharedPointer<Shader> ShaderPtr;
@@ -105,6 +106,7 @@ typedef QSharedPointer<VertexBuffer> VertexBufferPtr;
 typedef QSharedPointer<IndexBuffer> IndexBufferPtr;
 typedef QSharedPointer<GraphicsDevice> GraphicsDevicePtr;
 typedef QSharedPointer<SpriteBatch> SpriteBatchPtr;
+typedef QSharedPointer<Font> FontPtr;
 
 
 

--- a/src/irisgl/src/widgets/renderwidget.cpp
+++ b/src/irisgl/src/widgets/renderwidget.cpp
@@ -1,4 +1,5 @@
 #include "renderwidget.h"
+#include "../graphics/spritebatch.h"
 #include <QTimer>
 #include <QElapsedTimer>
 
@@ -47,9 +48,12 @@ void RenderWidget::initializeGL()
     initializeOpenGLFunctions();
 
     device = GraphicsDevice::create();
+    spriteBatch = SpriteBatch::create(device);
 
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_CULL_FACE);
+
+    device->setViewport(this->geometry());
 
     start();
 
@@ -58,7 +62,7 @@ void RenderWidget::initializeGL()
     updateTimer->start();
 
     elapsedTimer->start();
-    qDebug()<<"initializing";
+    //qDebug()<<"initializing";
 }
 
 void RenderWidget::paintGL()

--- a/src/irisgl/src/widgets/renderwidget.cpp
+++ b/src/irisgl/src/widgets/renderwidget.cpp
@@ -1,5 +1,6 @@
 #include "renderwidget.h"
 #include "../graphics/spritebatch.h"
+#include "../content/contentmanager.h"
 #include <QTimer>
 #include <QElapsedTimer>
 
@@ -48,6 +49,7 @@ void RenderWidget::initializeGL()
     initializeOpenGLFunctions();
 
     device = GraphicsDevice::create();
+    content = ContentManager::create(device);
     spriteBatch = SpriteBatch::create(device);
 
     glEnable(GL_DEPTH_TEST);

--- a/src/irisgl/src/widgets/renderwidget.cpp
+++ b/src/irisgl/src/widgets/renderwidget.cpp
@@ -1,0 +1,74 @@
+#include "renderwidget.h"
+#include <QTimer>
+#include <QElapsedTimer>
+
+namespace iris
+{
+
+void RenderWidget::start()
+{
+
+}
+
+void RenderWidget::update(float dt)
+{
+
+}
+
+void RenderWidget::render()
+{
+
+}
+
+RenderWidget::RenderWidget(QWidget *parent)
+{
+    QSurfaceFormat format;
+    format.setDepthBufferSize(32);
+    format.setMajorVersion(3);
+    format.setMinorVersion(2);
+    format.setProfile(QSurfaceFormat::CoreProfile);
+    format.setSamples(1);
+
+    setFormat(format);
+    // needed in order to get mouse events
+    setMouseTracking(true);
+
+    // needed in order to get key events
+    // http://stackoverflow.com/a/7879484/991834
+    setFocusPolicy(Qt::ClickFocus);
+
+    elapsedTimer = new QElapsedTimer();
+}
+
+void RenderWidget::initializeGL()
+{
+    makeCurrent();
+
+    initializeOpenGLFunctions();
+
+    device = GraphicsDevice::create();
+
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_CULL_FACE);
+
+    start();
+
+    auto updateTimer = new QTimer(this);
+    connect(updateTimer, SIGNAL(timeout()), this, SLOT(update()));
+    updateTimer->start();
+
+    elapsedTimer->start();
+    qDebug()<<"initializing";
+}
+
+void RenderWidget::paintGL()
+{
+    float dt = elapsedTimer->nsecsElapsed() / (1000.0f * 1000.0f * 1000.0f);
+    elapsedTimer->restart();
+
+    update(dt);
+    render();
+}
+
+
+}

--- a/src/irisgl/src/widgets/renderwidget.h
+++ b/src/irisgl/src/widgets/renderwidget.h
@@ -20,7 +20,7 @@ class RenderWidget : public QOpenGLWidget,
     QTimer* updateTimer;
 protected:
     GraphicsDevicePtr device;
-    //ContentManagerPtr content;
+    ContentManagerPtr content;
     SpriteBatchPtr spriteBatch;
 public:
     explicit RenderWidget(QWidget *parent);

--- a/src/irisgl/src/widgets/renderwidget.h
+++ b/src/irisgl/src/widgets/renderwidget.h
@@ -1,0 +1,37 @@
+#ifndef RENDERVIEW_H
+#define RENDERVIEW_H
+
+#include <QOpenGLWidget>
+#include <QOpenGLFunctions_3_2_Core>
+
+#include "../irisglfwd.h"
+#include "../graphics/graphicsdevice.h"
+
+class QElapsedTimer;
+class QTimer;
+
+namespace iris
+{
+
+class RenderWidget : public QOpenGLWidget,
+                     protected QOpenGLFunctions_3_2_Core
+{
+    QElapsedTimer* elapsedTimer;
+    QTimer* updateTimer;
+protected:
+    GraphicsDevicePtr device;
+    //ContentManagerPtr content;
+    //SpriteBatchPtr spriteBatch;
+public:
+    explicit RenderWidget(QWidget *parent);
+    void initializeGL();
+    void paintGL();
+
+    virtual void start();
+    virtual void update(float dt);
+    virtual void render();
+};
+
+}
+
+#endif // RENDERVIEW_H

--- a/src/irisgl/src/widgets/renderwidget.h
+++ b/src/irisgl/src/widgets/renderwidget.h
@@ -21,7 +21,7 @@ class RenderWidget : public QOpenGLWidget,
 protected:
     GraphicsDevicePtr device;
     //ContentManagerPtr content;
-    //SpriteBatchPtr spriteBatch;
+    SpriteBatchPtr spriteBatch;
 public:
     explicit RenderWidget(QWidget *parent);
     void initializeGL();

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -34,6 +34,8 @@ For more information see the LICENSE file
 #include "../irisgl/src/graphics/viewport.h"
 #include "../irisgl/src/graphics/renderlist.h"
 #include "../irisgl/src/graphics/rendertarget.h"
+#include "../irisgl/src/graphics/font.h"
+#include "../irisgl/src/graphics/spritebatch.h"
 #include "../irisgl/src/graphics/utils/fullscreenquad.h"
 #include "../irisgl/src/vr/vrmanager.h"
 #include "../irisgl/src/vr/vrdevice.h"
@@ -264,6 +266,8 @@ void SceneViewWidget::initializeGL()
     glEnable(GL_CULL_FACE);
 
     renderer = iris::ForwardRenderer::create();
+    spriteBatch = iris::SpriteBatch::create(renderer->getGraphicsDevice());
+    font = iris::Font::create(renderer->getGraphicsDevice(), 10);
 
     initialize();
     fsQuad = new iris::FullScreenQuad();
@@ -305,6 +309,7 @@ void SceneViewWidget::paintGL()
     }
 
     renderScene();
+
 }
 
 void SceneViewWidget::renderScene()
@@ -382,6 +387,13 @@ void SceneViewWidget::renderScene()
 
         this->updateScene();
     }
+
+    // render fps
+    float fps = 1.0/dt;
+    spriteBatch->begin();
+    spriteBatch->drawString(font, QString("fps: %1").arg(fps), QVector2D(0, 0), QColor(255, 255, 255));
+    spriteBatch->end();
+
 }
 
 void SceneViewWidget::resizeGL(int width, int height)

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -389,9 +389,15 @@ void SceneViewWidget::renderScene()
     }
 
     // render fps
-    float fps = 1.0/dt;
+    float fps = 1.0 / dt;
+    float ms = 1000.f / fps;
     spriteBatch->begin();
-    spriteBatch->drawString(font, QString("fps: %1").arg(fps), QVector2D(0, 0), QColor(255, 255, 255));
+    spriteBatch->drawString(font,
+                            QString("Frametime: %1ms (%2fps)")
+                                .arg(QString::number(ms, 'f', 1))
+                                .arg(QString::number(fps, 'f', 1)),
+                            QVector2D(8, 8),
+                            QColor(255, 255, 255));
     spriteBatch->end();
 
 }

--- a/src/widgets/sceneviewwidget.h
+++ b/src/widgets/sceneviewwidget.h
@@ -90,6 +90,10 @@ class SceneViewWidget : public QOpenGLWidget, protected QOpenGLFunctions_3_2_Cor
     // for screenshots
     iris::RenderTargetPtr screenshotRT;
     iris::Texture2DPtr screenshotTex;
+
+    // for rendering text
+    iris::SpriteBatchPtr spriteBatch;
+    iris::FontPtr font;
 public:
     iris::CameraNodePtr editorCam;
 


### PR DESCRIPTION
A GraphicsDevice class was added which should be used as an easy way to interface with OpenGL moving forward. All the basics needed from a rendering api are now wrapped in classes; VertexBuffer/IndexBuffer, VertexLayout, Shader, Texture2D, Rendertarget, SpriteBatch, Font. Additional classes like DepthState, BlendState and RasterizerState are to be used for a much simpler way to manage OpenGL states. These, in conjunction with GraphicsDevice, are enough to cover all of Jahshaka's current rendering needs.