### PR TITLE
Add thumbnail previews of 3d models in asset manager

### DIFF
--- a/Jahshaka.pro
+++ b/Jahshaka.pro
@@ -113,7 +113,8 @@ SOURCES += src/main.cpp\
     src/widgets/dynamicgrid.cpp \
     src/widgets/gridwidget.cpp \
     src/widgets/itemgridwidget.cpp \
-    src/dialogs/renameprojectdialog.cpp
+    src/dialogs/renameprojectdialog.cpp \
+    src/editor/thumbnailgenerator.cpp
 
 HEADERS  += src/mainwindow.h \
     src/dialogs/renamelayerdialog.h \
@@ -217,7 +218,8 @@ HEADERS  += src/mainwindow.h \
     src/widgets/dynamicgrid.h \
     src/widgets/gridwidget.h \
     src/widgets/itemgridwidget.hpp \
-    src/dialogs/renameprojectdialog.h
+    src/dialogs/renameprojectdialog.h \
+    src/editor/thumbnailgenerator.h
 
 FORMS    += \
     src/dialogs/renamelayerdialog.ui \

--- a/src/core/thumbnailmanager.cpp
+++ b/src/core/thumbnailmanager.cpp
@@ -24,26 +24,40 @@ QSharedPointer<Thumbnail> ThumbnailManager::createThumbnail(QString filename, in
     // assumes file exist for now
     QFileInfo fileInfo(filename);
     auto lastModified = fileInfo.lastModified();
-    auto hash = filename+lastModified.toMSecsSinceEpoch();
+    auto hash = filename+lastModified.toMSecsSinceEpoch()+QString("-")+width+QString("-")+height;
 
-    if (ThumbnailManager::thumbnails.contains(filename)) {
-        return ThumbnailManager::thumbnails[filename];
+    if (ThumbnailManager::thumbnails.contains(hash)) {
+        return ThumbnailManager::thumbnails[hash];
     }
+
+    QImage image;
+    if (cachedImages.contains(filename))
+        image = cachedImages[filename];
+    else {
+        image = QImage(filename);
+    }
+
 
     auto thumb = new Thumbnail;
     thumb->filePath = filename;
-
-    QImage image(filename);
     thumb->thumbSize = QSize(width, height);
     thumb->originalSize = image.size();
     thumb->thumb = new QImage(image.scaled(thumb->thumbSize, Qt::KeepAspectRatioByExpanding));
 
 
     auto thumbPtr = QSharedPointer<Thumbnail>(thumb);
-    ThumbnailManager::thumbnails.insert(filename, thumbPtr);
+    ThumbnailManager::thumbnails.insert(hash, thumbPtr);
 
     return thumbPtr;
 }
 
+void ThumbnailManager::cacheImage(QString filename, QImage image)
+{
+    cachedImages.insert(filename, image);
+}
+
 QHash<QString, QSharedPointer<Thumbnail>> ThumbnailManager::thumbnails =
         QHash<QString, QSharedPointer<Thumbnail>>();
+
+QHash<QString, QImage> ThumbnailManager::cachedImages =
+        QHash<QString, QImage>();

--- a/src/core/thumbnailmanager.h
+++ b/src/core/thumbnailmanager.h
@@ -43,6 +43,10 @@ class ThumbnailManager
 public:
     static QSharedPointer<Thumbnail> createThumbnail(QString filename, int width, int height);
     static QHash<QString, QSharedPointer<Thumbnail>> thumbnails;
+
+    static void cacheImage(QString filename, QImage image);
+    // this is for images generated at runtime that dont have physical files associated with them
+    static QHash<QString, QImage> cachedImages;
 };
 
 

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -30,6 +30,7 @@ void RenderThread::requestThumbnail(const ThumbnailRequest &request)
 
 void RenderThread::run()
 {
+    this->setPriority(QThread::LowestPriority);
     context->makeCurrent(surface);
     initScene();
 
@@ -73,6 +74,7 @@ void RenderThread::run()
 
             emit thumbnailComplete(result);
         }
+
     }
 
     // move to main thread to be cleaned up

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -34,6 +34,8 @@ void RenderThread::run()
     renderTarget->addTexture(tex);
 
     while(true) {
+        //exec(); // handle event loops
+
         //qDebug()<<"rendering";
         ThumbnailRequest request;
         bool hasRequest = false;
@@ -49,10 +51,10 @@ void RenderThread::run()
         if (hasRequest) {
 
             prepareScene(request);
-            scene->rootNode->addChild(sceneNode);
+            //scene->rootNode->addChild(sceneNode);
 
             scene->update(0);
-            renderer->renderSceneToRenderTarget(renderTarget, cam, false);
+            renderer->renderSceneToRenderTarget(renderTarget, cam, true);
 
             cleanupScene();
             //meshNode->
@@ -62,11 +64,11 @@ void RenderThread::run()
             //todo: strip alpha channel from image
             img.save("/home/nicolas/Desktop/screenshot_thumb.jpg");
 
-            ThumbnailResult result;
-            result.id = request.id;
-            result.type = request.type;
-            result.path = request.path;
-            result.thumbnail = img;
+            auto result = new ThumbnailResult;
+            result->id = request.id;
+            result->type = request.type;
+            result->path = request.path;
+            result->thumbnail = img;
 
             emit thumbnailComplete(result);
         }
@@ -90,7 +92,7 @@ void RenderThread::initScene()
     //cam->setLocalRot(QQuaternion::fromEulerAngles(-45, 45, 0));
     cam->lookAt(QVector3D(0,0.5f,0));
 
-    scene->setSkyColor(QColor(50, 50, 50));
+    scene->setSkyColor(QColor(100, 100, 100));
     scene->setAmbientColor(QColor(255, 255, 255));
 
     // second node
@@ -118,7 +120,7 @@ void RenderThread::initScene()
     scene->rootNode->addChild(dlight);
     dlight->setName("Directional Light");
     dlight->setLocalPos(QVector3D(4, 4, 0));
-    dlight->setLocalRot(QQuaternion::fromEulerAngles(15, 0, 0));
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(45, 0, 0));
     dlight->intensity = 1;
     //dlight->icon = iris::Texture2D::load(":/icons/light.png");
 
@@ -176,11 +178,9 @@ void RenderThread::prepareScene(const ThumbnailRequest &request)
         auto boundRadius = getBoundingRadius(sceneNode);
 
 
-        cam->setLocalPos(QVector3D(1, 1, 5).normalized()*(boundRadius+5));
+        cam->setLocalPos(QVector3D(1, 1, 5).normalized()*(boundRadius+2));
         cam->lookAt(QVector3D(0, boundRadius/2.0f, 0));
         cam->update(0);
-
-        // apply default material
     }
     else
     {
@@ -194,7 +194,8 @@ void RenderThread::prepareScene(const ThumbnailRequest &request)
 
 void RenderThread::cleanupScene()
 {
-    scene->rootNode->removeChild(sceneNode);
+    //scene->rootNode->removeChild(sceneNode);
+    sceneNode->removeFromParent();
 }
 
 float RenderThread::getBoundingRadius(iris::SceneNodePtr node)

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -202,7 +202,7 @@ float RenderThread::getBoundingRadius(iris::SceneNodePtr node)
 {
     auto radius = 0.0f;
     if(node->sceneNodeType== iris::SceneNodeType::Mesh)
-        radius = node.staticCast<iris::MeshNode>()->getMesh()->boundingSphere->radius;
+        radius = node.staticCast<iris::MeshNode>()->getMesh()->boundingSphere.radius;
 
     for(auto child : node->children) {
         radius = qMax(radius, getBoundingRadius(child));

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -1,0 +1,64 @@
+#include "thumbnailgenerator.h"
+#include <QOpenGLFunctions_3_2_Core>
+
+#include "../irisgl/src/graphics/rendertarget.h"
+#include "../irisgl/src/graphics/texture2d.h"
+
+void RenderThread::run()
+{
+    context->makeCurrent(surface);
+    auto gl = context->versionFunctions<QOpenGLFunctions_3_2_Core>();
+
+    //renderer = iris::ForwardRenderer::create();
+    //scene = iris::Scene::create();
+
+    // create scene and renderer
+    //cam = iris::CameraNode::create();
+    //cam->setLocalPos(QVector3D(0, 5, 14));
+    //cam->setLocalRot(QQuaternion::fromEulerAngles(-5, 0, 0));
+
+    renderTarget = iris::RenderTarget::create(500, 500);
+    tex = iris::Texture2D::create(500, 500);
+    renderTarget->addTexture(tex);
+
+    renderTarget->bind();
+    // render scene to fbo
+    gl->glClearColor(255,0,0,255);
+    gl->glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+    gl->glViewport(0,0,500,500);
+    //scene->update(0);
+    //renderer->renderSceneToRenderTarget(renderTarget, cam, false);
+    renderTarget->unbind();
+
+    // save contents to file
+    auto img = renderTarget->toImage();
+    img.save("/home/nicolas/Desktop/screenshot_thumb.png");
+}
+
+ThumbnialGenerator::ThumbnialGenerator()
+{
+    renderThread = new RenderThread();
+
+    auto curCtx = QOpenGLContext::currentContext();
+    curCtx->doneCurrent();
+
+    auto context = new QOpenGLContext();
+    context->setFormat(curCtx->format());
+    context->setShareContext(curCtx);
+    context->create();
+    context->moveToThread(renderThread);
+    renderThread->context = context;
+
+    auto surface = new QOffscreenSurface();
+    surface->setFormat(context->format());
+    surface->create();
+    surface->moveToThread(renderThread);
+    renderThread->surface = surface;
+
+    renderThread->start();
+}
+
+void ThumbnialGenerator::run()
+{
+    //renderThread->start();
+}

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -63,8 +63,6 @@ void RenderThread::run()
 
             // save contents to file
             auto img = renderTarget->toImage();
-            //todo: strip alpha channel from image
-            img.save("/home/nicolas/Desktop/screenshot_thumb.jpg");
 
             auto result = new ThumbnailResult;
             result->id = request.id;

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -118,19 +118,27 @@ void RenderThread::initScene()
     auto dlight = iris::LightNode::create();
     dlight->setLightType(iris::LightType::Directional);
     scene->rootNode->addChild(dlight);
-    dlight->setName("Directional Light");
-    dlight->setLocalPos(QVector3D(4, 4, 0));
-    dlight->setLocalRot(QQuaternion::fromEulerAngles(45, 0, 0));
+    dlight->setName("Key Light");
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(45, -45, 0));
     dlight->intensity = 1;
     //dlight->icon = iris::Texture2D::load(":/icons/light.png");
 
     auto plight = iris::LightNode::create();
-    plight->setLightType(iris::LightType::Point);
+    plight->setLightType(iris::LightType::Directional);
     scene->rootNode->addChild(plight);
-    plight->setName("Point Light");
-    plight->setLocalPos(QVector3D(-4, 4, 0));
+    plight->setName("Fill Light");
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(90, 180, 90));
     plight->intensity = 1;
+    plight->color = QColor(255, 200, 200);
     //plight->icon = iris::Texture2D::load(":/icons/bulb.png");
+
+    plight = iris::LightNode::create();
+    plight->setLightType(iris::LightType::Directional);
+    scene->rootNode->addChild(plight);
+    plight->setName("Rim Light");
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(60, 0, 0));
+    plight->intensity = 1;
+    plight->color = QColor(200, 222, 200);
 
     // fog params
     scene->fogColor = QColor(72, 72, 72);
@@ -138,6 +146,7 @@ void RenderThread::initScene()
     scene->shadowEnabled = false;
 
     cam->update(0);// necessary!
+    scene->update(0);
 }
 
 void RenderThread::prepareScene(const ThumbnailRequest &request)

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -120,7 +120,7 @@ void RenderThread::initScene()
     scene->rootNode->addChild(dlight);
     dlight->setName("Directional Light");
     dlight->setLocalPos(QVector3D(4, 4, 0));
-    dlight->setLocalRot(QQuaternion::fromEulerAngles(-45, 0, 0));
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(45, 0, 0));
     dlight->intensity = 1;
     //dlight->icon = iris::Texture2D::load(":/icons/light.png");
 
@@ -196,7 +196,7 @@ void RenderThread::prepareScene(const ThumbnailRequest &request)
 
 
         float dist = (bound.radius*1.2) / qTan(qDegreesToRadians(cam->angle/2.0f));
-        cam->setLocalPos(QVector3D(0, bound.pos.y(), -dist));
+        cam->setLocalPos(QVector3D(0, bound.pos.y(), dist));
         cam->lookAt(bound.pos);
         cam->update(0);
     }

--- a/src/editor/thumbnailgenerator.cpp
+++ b/src/editor/thumbnailgenerator.cpp
@@ -1,38 +1,99 @@
 #include "thumbnailgenerator.h"
 #include <QOpenGLFunctions_3_2_Core>
 
+#include "../constants.h"
+
 #include "../irisgl/src/graphics/rendertarget.h"
 #include "../irisgl/src/graphics/texture2d.h"
+#include "../irisgl/src/graphics/forwardrenderer.h"
+#include "../irisgl/src/scenegraph/scene.h"
+#include "../irisgl/src/scenegraph/lightnode.h"
+#include "../irisgl/src/scenegraph/cameranode.h"
+#include "../irisgl/src/scenegraph/meshnode.h"
+#include "../irisgl/src/materials/custommaterial.h"
 
 void RenderThread::run()
 {
     context->makeCurrent(surface);
     auto gl = context->versionFunctions<QOpenGLFunctions_3_2_Core>();
+    gl->glEnable(GL_DEPTH_TEST);
+    gl->glEnable(GL_CULL_FACE);
+    gl->glDisable(GL_BLEND);
 
-    //renderer = iris::ForwardRenderer::create();
-    //scene = iris::Scene::create();
+    renderer = iris::ForwardRenderer::create();
+    scene = iris::Scene::create();
+    renderer->setScene(scene);
 
     // create scene and renderer
-    //cam = iris::CameraNode::create();
-    //cam->setLocalPos(QVector3D(0, 5, 14));
-    //cam->setLocalRot(QQuaternion::fromEulerAngles(-5, 0, 0));
+    cam = iris::CameraNode::create();
+    cam->setLocalPos(QVector3D(0, 5, 14));
+    cam->setLocalRot(QQuaternion::fromEulerAngles(-30, 0, 0));
+
+    scene->setSkyColor(QColor(255, 72, 72));
+    scene->setAmbientColor(QColor(255, 255, 255));
+
+    // second node
+    auto node = iris::MeshNode::create();
+    node->setMesh(":/models/cube.obj");
+    node->setLocalPos(QVector3D(0, 0, 0)); // prevent z-fighting with the default plane
+    node->setName("Ground");
+    node->setPickable(false);
+    node->setShadowEnabled(false);
+
+    auto m = iris::CustomMaterial::create();
+    m->generate(IrisUtils::getAbsoluteAssetPath(Constants::DEFAULT_SHADER));
+    m->setValue("diffuseTexture", ":/content/textures/tile.png");
+    //m->setValue("diffuseTexture", ":/content/skies/alternative/cove/back.jpg");
+    m->setValue("textureScale", 4.f);
+    //m->setValue("emission",QColor(255, 255, 255));
+    m->setValue("diffuseColor", QColor(255, 255, 255, 255));
+    m->setValue("useAlpha", false);
+    node->setMaterial(m);
+
+    scene->rootNode->addChild(node);
+
+    auto dlight = iris::LightNode::create();
+    dlight->setLightType(iris::LightType::Directional);
+    scene->rootNode->addChild(dlight);
+    dlight->setName("Directional Light");
+    dlight->setLocalPos(QVector3D(4, 4, 0));
+    dlight->setLocalRot(QQuaternion::fromEulerAngles(15, 0, 0));
+    dlight->intensity = 1;
+    dlight->icon = iris::Texture2D::load(":/icons/light.png");
+
+    auto plight = iris::LightNode::create();
+    plight->setLightType(iris::LightType::Point);
+    scene->rootNode->addChild(plight);
+    plight->setName("Point Light");
+    plight->setLocalPos(QVector3D(-4, 4, 0));
+    plight->intensity = 1;
+    plight->icon = iris::Texture2D::load(":/icons/bulb.png");
+
+    // fog params
+    scene->fogColor = QColor(72, 72, 72);
+    scene->fogEnabled = false;
+    scene->shadowEnabled = false;
+
 
     renderTarget = iris::RenderTarget::create(500, 500);
     tex = iris::Texture2D::create(500, 500);
     renderTarget->addTexture(tex);
 
-    renderTarget->bind();
+    //renderTarget->bind();
     // render scene to fbo
     gl->glClearColor(255,0,0,255);
     gl->glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
     gl->glViewport(0,0,500,500);
-    //scene->update(0);
-    //renderer->renderSceneToRenderTarget(renderTarget, cam, false);
-    renderTarget->unbind();
+    scene->update(0);
+    cam->update(0);// necessary!
+
+    renderer->renderSceneToRenderTarget(renderTarget, cam, false);
+    //renderTarget->unbind();
 
     // save contents to file
     auto img = renderTarget->toImage();
-    img.save("/home/nicolas/Desktop/screenshot_thumb.png");
+    //todo: strip alpha channel from image
+    img.save("/home/nicolas/Desktop/screenshot_thumb.jpg");
 }
 
 ThumbnialGenerator::ThumbnialGenerator()

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -43,7 +43,7 @@ public:
 
     iris::ForwardRendererPtr renderer;
     iris::ScenePtr scene;
-    iris::MeshNodePtr meshNode;
+    iris::SceneNodePtr sceneNode;
 
     iris::CameraNodePtr cam;
     iris::CustomMaterialPtr material;
@@ -61,6 +61,7 @@ public:
 
 private:
     //ThumbnailRequest& getRequest();
+    float getBoundingRadius(iris::SceneNodePtr node);
 
 signals:
     void thumbnailComplete(const ThumbnailResult& result);

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -7,6 +7,7 @@
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_3_2_Core>
 #include <QMutex>
+#include <QImage>
 
 enum class ThumbnailRequestType
 {
@@ -32,6 +33,7 @@ struct ThumbnailResult
 
 class RenderThread : public QThread
 {
+    Q_OBJECT
 public:
     QOffscreenSurface *surface;
     QOpenGLContext *context;
@@ -65,11 +67,15 @@ signals:
 };
 
 // http://doc.qt.io/qt-5/qtquick-scenegraph-textureinthread-threadrenderer-cpp.html
-class ThumbnialGenerator
+class ThumbnailGenerator
 {
-    RenderThread* renderThread;
+    static ThumbnailGenerator* instance;
+    ThumbnailGenerator();
 public:
-    ThumbnialGenerator();
+    RenderThread* renderThread;
+
+    static ThumbnailGenerator* getSingleton();
+
     void requestThumbnail(ThumbnailRequestType type, QString path, QString id = "");
 };
 

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -7,6 +7,7 @@
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_3_2_Core>
 #include <QMutex>
+#include <QSemaphore>
 #include <QImage>
 
 enum class ThumbnailRequestType
@@ -50,6 +51,9 @@ public:
 
     QMutex requestMutex;
     QList<ThumbnailRequest> requests;
+    QSemaphore requestsAvailable;
+
+    bool shutdown;
 
     void requestThumbnail(const ThumbnailRequest& request);
 
@@ -80,6 +84,9 @@ public:
     static ThumbnailGenerator* getSingleton();
 
     void requestThumbnail(ThumbnailRequestType type, QString path, QString id = "");
+
+    // must be called to properly shutdown ui components
+    void shutdown();
 };
 
 #endif // THUMBNAILGENERATOR_H

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -59,12 +59,14 @@ public:
     void prepareScene(const ThumbnailRequest& request);
     void cleanupScene();
 
+signals:
+    void thumbnailComplete(ThumbnailResult* result);
+
 private:
     //ThumbnailRequest& getRequest();
     float getBoundingRadius(iris::SceneNodePtr node);
 
-signals:
-    void thumbnailComplete(const ThumbnailResult& result);
+
 };
 
 // http://doc.qt.io/qt-5/qtquick-scenegraph-textureinthread-threadrenderer-cpp.html

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -65,7 +65,7 @@ signals:
 private:
     //ThumbnailRequest& getRequest();
     float getBoundingRadius(iris::SceneNodePtr node);
-
+    void getBoundingSpheres(iris::SceneNodePtr node, QList<iris::BoundingSphere>& spheres);
 
 };
 

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -6,7 +6,29 @@
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_3_2_Core>
+#include <QMutex>
 
+enum class ThumbnailRequestType
+{
+    Material,
+    Mesh
+};
+
+struct ThumbnailRequest
+{
+public:
+    ThumbnailRequestType type;
+    QString path;
+    QString id;
+};
+
+struct ThumbnailResult
+{
+    ThumbnailRequestType type;
+    QString path;
+    QString id;
+    QImage thumbnail;
+};
 
 class RenderThread : public QThread
 {
@@ -19,11 +41,27 @@ public:
 
     iris::ForwardRendererPtr renderer;
     iris::ScenePtr scene;
+    iris::MeshNodePtr meshNode;
 
     iris::CameraNodePtr cam;
+    iris::CustomMaterialPtr material;
+
+    QMutex requestMutex;
+    QList<ThumbnailRequest> requests;
+
+    void requestThumbnail(const ThumbnailRequest& request);
 
     void run() override;
 
+    void initScene();
+    void prepareScene(const ThumbnailRequest& request);
+    void cleanupScene();
+
+private:
+    //ThumbnailRequest& getRequest();
+
+signals:
+    void thumbnailComplete(const ThumbnailResult& result);
 };
 
 // http://doc.qt.io/qt-5/qtquick-scenegraph-textureinthread-threadrenderer-cpp.html
@@ -32,7 +70,7 @@ class ThumbnialGenerator
     RenderThread* renderThread;
 public:
     ThumbnialGenerator();
-    void run();
+    void requestThumbnail(ThumbnailRequestType type, QString path, QString id = "");
 };
 
 #endif // THUMBNAILGENERATOR_H

--- a/src/editor/thumbnailgenerator.h
+++ b/src/editor/thumbnailgenerator.h
@@ -1,0 +1,38 @@
+#ifndef THUMBNAILGENERATOR_H
+#define THUMBNAILGENERATOR_H
+
+#include "../irisgl/src/irisglfwd.h"
+#include <QThread>
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFunctions_3_2_Core>
+
+
+class RenderThread : public QThread
+{
+public:
+    QOffscreenSurface *surface;
+    QOpenGLContext *context;
+
+    iris::Texture2DPtr tex;
+    iris::RenderTargetPtr renderTarget;
+
+    iris::ForwardRendererPtr renderer;
+    iris::ScenePtr scene;
+
+    iris::CameraNodePtr cam;
+
+    void run() override;
+
+};
+
+// http://doc.qt.io/qt-5/qtquick-scenegraph-textureinthread-threadrenderer-cpp.html
+class ThumbnialGenerator
+{
+    RenderThread* renderThread;
+public:
+    ThumbnialGenerator();
+    void run();
+};
+
+#endif // THUMBNAILGENERATOR_H

--- a/src/io/assetmanager.cpp
+++ b/src/io/assetmanager.cpp
@@ -1,3 +1,23 @@
 #include "assetmanager.h"
 
 QList<Asset*> AssetManager::assets;
+
+QList<Asset *> &AssetManager::getAssets()
+{
+    return assets;
+}
+
+void AssetManager::addAsset(Asset *asset)
+{
+    assets.append(asset);
+    //assetsByPath.insert(asset->path, asset);
+}
+
+Asset *AssetManager::getAssetByPath(QString absolutePath)
+{
+    for (auto asset : assets)
+        if (asset->path == absolutePath)
+            return asset;
+
+    return nullptr;
+}

--- a/src/io/assetmanager.h
+++ b/src/io/assetmanager.h
@@ -115,9 +115,18 @@ struct AssetObject : public Asset
 
 class AssetManager
 {
+
+    //static QMap<QString, Asset*> assetsByPath;
 public:
-    AssetManager();
     static QList<Asset*> assets;
+    static QList<Asset*>& getAssets();
+    static void addAsset(Asset* asset);
+
+    // returns asset by path
+    // return null if no asset exists
+    static Asset* getAssetByPath(QString absolutePath);
+
+
 };
 
 #endif // ASSETMANAGER_H

--- a/src/io/scenereader.cpp
+++ b/src/io/scenereader.cpp
@@ -540,7 +540,7 @@ iris::MaterialPtr SceneReader::readMaterial(QJsonObject& nodeObj)
     if (shaderFile.exists()) {
         m->generate(shaderFile.absoluteFilePath());
     } else {
-        for (auto asset : AssetManager::assets) {
+        for (auto asset : AssetManager::getAssets()) {
             if (asset->type == AssetType::Shader) {
                 if (asset->fileName == mat["name"].toString() + ".shader") {
                     //qDebug() << asset->path;
@@ -572,7 +572,7 @@ void SceneReader::extractAssetsFromAssimpScene(QString filePath)
     if (!assimpScenes.contains(filePath)) {
         QList<iris::MeshPtr> meshList;
         QMap<QString, iris::SkeletalAnimationPtr> animationss;
-        iris::GraphicsHelper::loadAllMeshesAndAnimationsFromStore<Asset*>(AssetManager::assets,
+        iris::GraphicsHelper::loadAllMeshesAndAnimationsFromStore<Asset*>(AssetManager::getAssets(),
                                                                           filePath,
                                                                           meshList,
                                                                           animationss);

--- a/src/irisgl/src/geometry/boundingsphere.h
+++ b/src/irisgl/src/geometry/boundingsphere.h
@@ -19,9 +19,35 @@ public:
             radius =dist;
     }
 
-    bool intersects(BoundingSphere* other)
+    bool intersects(const BoundingSphere& other)
     {
-        return pos.distanceToPoint(other->pos) < radius + other->radius;
+        return pos.distanceToPoint(other.pos) < radius + other.radius;
+    }
+
+    static BoundingSphere merge(const BoundingSphere& a, const BoundingSphere& b)
+    {
+        QVector3D center = b.pos - a.pos;
+        auto dist = center.length();
+
+        // handle the case where one sphere might be in the next
+        if (dist < a.radius + b.radius) {
+            if (dist <= a.radius - b.radius)
+                return a;
+
+            if (dist <= b.radius - a.radius)
+                return b;
+        }
+
+        float aRad = qMax(a.radius - dist, b.radius);
+        float bRad = qMax(a.radius + dist, b.radius);
+
+        center = center + (((aRad - bRad) / (2 * center.length())) * center);
+
+        BoundingSphere mergedSphere;
+        mergedSphere.pos = a.pos + center;
+        mergedSphere.radius = (aRad + bRad) / 2.0f;
+
+        return mergedSphere;
     }
 };
 

--- a/src/irisgl/src/graphics/forwardrenderer.cpp
+++ b/src/irisgl/src/graphics/forwardrenderer.cpp
@@ -683,13 +683,14 @@ void ForwardRenderer::renderBillboardIcons(RenderData* renderData)
         if(!!icon)
         {
             icon->texture->bind();
+            billboard->draw(gl);
         }
         else
         {
             gl->glBindTexture(GL_TEXTURE_2D,0);
         }
 
-        billboard->draw(gl);
+
     }
     gl->glDisable(GL_BLEND);
 

--- a/src/irisgl/src/graphics/mesh.cpp
+++ b/src/irisgl/src/graphics/mesh.cpp
@@ -23,6 +23,7 @@ For more information see the LICENSE file
 #include <QOpenGLBuffer>
 #include <QOpenGLFunctions_3_2_Core>
 #include <QOpenGLTexture>
+#include <QtMath>
 
 #include "vertexlayout.h"
 #include "../geometry/trimesh.h"
@@ -65,8 +66,6 @@ Mesh::Mesh(aiMesh* mesh)
     numFaces = mesh->mNumFaces;
 
     gl->glGenVertexArrays(1,&vao);
-
-    boundingSphere = new BoundingSphere();
 
     if(!mesh->HasPositions())
         return;
@@ -152,11 +151,6 @@ Mesh::Mesh(aiMesh* mesh)
         triMesh->addTriangle(QVector3D(a.x, a.y, a.z),
                              QVector3D(b.x, b.y, b.z),
                              QVector3D(c.x, c.y, c.z));
-
-        // redundant, but good enough for now
-        boundingSphere->expand(QVector3D(a.x, a.y, a.z));
-        boundingSphere->expand(QVector3D(b.x, b.y, b.z));
-        boundingSphere->expand(QVector3D(c.x, c.y, c.z));
     }
 
     gl->glGenBuffers(1, &indexBuffer);
@@ -170,6 +164,7 @@ Mesh::Mesh(aiMesh* mesh)
 
     this->setPrimitiveMode(PrimitiveMode::Triangles);
 
+    boundingSphere = calculateBoundingSphere(mesh);
 }
 
 //todo: extract trimesh from data
@@ -466,6 +461,47 @@ void Mesh::addVertexArray(VertexAttribUsage usage,void* dataPtr,int size,GLenum 
 void Mesh::addIndexArray(void* data,int size,GLenum type)
 {
 
+}
+
+// https://github.com/playcanvas/engine/blob/master/src/shape/bounding-sphere.js#L30
+// bounding sphere wont necessarily be at the center of the mesh's origin
+// the true positon in world space would be the bounds's center plus the mesh's absolute position
+BoundingSphere *Mesh::calculateBoundingSphere(const aiMesh *mesh)
+{
+    // find average pos
+    aiVector3D averagePos;// = mesh->mVertices[0];
+    aiVector3D sum(0,0,0);
+
+    for(unsigned int i =0;i<mesh->mNumVertices;i++) {
+        sum += mesh->mVertices[i];
+
+        if (i%100 == 0) {
+            sum /= mesh->mNumVertices;
+            averagePos += sum;
+            sum = aiVector3D(0,0,0);
+        }
+    }
+
+    sum/=mesh->mNumVertices;
+    averagePos += sum;
+
+    //averagePos = averagePos/mesh->mNumVertices;
+
+    // find furthest distance
+    float maxDistSqrd = 0;
+    for(unsigned int i =0;i<mesh->mNumVertices;i++) {
+        auto vert = mesh->mVertices[i];
+        auto diff = vert-averagePos;
+        auto dist = diff.SquareLength();
+
+        if (dist > maxDistSqrd)
+            maxDistSqrd = dist;
+    }
+
+    auto sphere = new BoundingSphere();
+    sphere->pos = QVector3D(averagePos.x, averagePos.y, averagePos.x);
+    sphere->radius = qSqrt(maxDistSqrd);
+    return sphere;
 }
 
 }

--- a/src/irisgl/src/graphics/mesh.cpp
+++ b/src/irisgl/src/graphics/mesh.cpp
@@ -466,7 +466,7 @@ void Mesh::addIndexArray(void* data,int size,GLenum type)
 // https://github.com/playcanvas/engine/blob/master/src/shape/bounding-sphere.js#L30
 // bounding sphere wont necessarily be at the center of the mesh's origin
 // the true positon in world space would be the bounds's center plus the mesh's absolute position
-BoundingSphere *Mesh::calculateBoundingSphere(const aiMesh *mesh)
+BoundingSphere Mesh::calculateBoundingSphere(const aiMesh *mesh)
 {
     // find average pos
     aiVector3D averagePos;// = mesh->mVertices[0];
@@ -498,9 +498,9 @@ BoundingSphere *Mesh::calculateBoundingSphere(const aiMesh *mesh)
             maxDistSqrd = dist;
     }
 
-    auto sphere = new BoundingSphere();
-    sphere->pos = QVector3D(averagePos.x, averagePos.y, averagePos.x);
-    sphere->radius = qSqrt(maxDistSqrd);
+    BoundingSphere sphere;
+    sphere.pos = QVector3D(averagePos.x, averagePos.y, averagePos.x);
+    sphere.radius = qSqrt(maxDistSqrd);
     return sphere;
 }
 

--- a/src/irisgl/src/graphics/mesh.h
+++ b/src/irisgl/src/graphics/mesh.h
@@ -154,6 +154,8 @@ public:
 private:
     void addVertexArray(VertexAttribUsage usage,void* data,int size,GLenum type,int numComponents);
     void addIndexArray(void* data,int size,GLenum type);
+
+    static BoundingSphere* calculateBoundingSphere(const aiMesh* mesh);
 };
 
 //typedef QSharedPointer<Mesh> MeshPtr;

--- a/src/irisgl/src/graphics/mesh.h
+++ b/src/irisgl/src/graphics/mesh.h
@@ -17,7 +17,7 @@ For more information see the LICENSE file
 #include <QColor>
 #include "../irisglfwd.h"
 #include "../animation/skeletalanimation.h"
-
+#include "../geometry/boundingsphere.h"
 
 class aiMesh;
 class aiScene;
@@ -96,7 +96,7 @@ public:
     GLuint indexBuffer;
     bool usesIndexBuffer;
 
-    BoundingSphere* boundingSphere;
+    BoundingSphere boundingSphere;
 
     // will cause problems if a shader was freed and gl gives the
     // id to another shader
@@ -155,7 +155,7 @@ private:
     void addVertexArray(VertexAttribUsage usage,void* data,int size,GLenum type,int numComponents);
     void addIndexArray(void* data,int size,GLenum type);
 
-    static BoundingSphere* calculateBoundingSphere(const aiMesh* mesh);
+    static BoundingSphere calculateBoundingSphere(const aiMesh* mesh);
 };
 
 //typedef QSharedPointer<Mesh> MeshPtr;

--- a/src/irisgl/src/graphics/rendertarget.cpp
+++ b/src/irisgl/src/graphics/rendertarget.cpp
@@ -46,7 +46,7 @@ RenderTarget::RenderTarget(int width, int height):
 
     gl->glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, renderBufferId);
 
-    checkStatus();
+    //checkStatus();
 
     gl->glBindRenderbuffer(GL_RENDERBUFFER, 0);
     gl->glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -133,7 +133,7 @@ void RenderTarget::clearRenderBuffer()
     gl->glBindFramebuffer(GL_FRAMEBUFFER, fboId);
     gl->glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, 0);
 
-    checkStatus();
+    //checkStatus();
 
     gl->glBindFramebuffer(GL_FRAMEBUFFER, 0);
 }
@@ -152,7 +152,7 @@ void RenderTarget::bind()
     if (!!depthTexture)
         gl->glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTexture->getTextureId(), 0);
 
-    checkStatus();
+    //checkStatus();
 }
 
 void RenderTarget::unbind()

--- a/src/irisgl/src/irisglfwd.h
+++ b/src/irisgl/src/irisglfwd.h
@@ -69,6 +69,7 @@ class Skeleton;
 class SkeletalAnimation;
 template<typename T> class Key;
 typedef Key<float> FloatKey;
+class BoundingSphere;
 
 typedef QSharedPointer<iris::Animation> AnimationPtr;
 typedef QSharedPointer<Shader> ShaderPtr;

--- a/src/irisgl/src/scenegraph/cameranode.cpp
+++ b/src/irisgl/src/scenegraph/cameranode.cpp
@@ -12,9 +12,21 @@ For more information see the LICENSE file
 #include "cameranode.h"
 #include <QVector3D>
 #include <QPoint>
+#include <QMatrix4x4>
+#include "../math/mathhelper.h"
 
 namespace iris
 {
+
+void CameraNode::lookAt(QVector3D target)
+{
+    //todo: use global matrices
+    QMatrix4x4 matrix;
+    matrix.setToIdentity();
+    matrix.lookAt(pos, target, QVector3D(0,1,0));
+    matrix = matrix.inverted();
+    MathHelper::decomposeMatrix(matrix, pos, rot, scale);
+}
 
 QVector3D CameraNode::calculatePickingDirection(int viewPortWidth, int viewPortHeight,QPointF pos)
 {

--- a/src/irisgl/src/scenegraph/cameranode.h
+++ b/src/irisgl/src/scenegraph/cameranode.h
@@ -60,6 +60,8 @@ public:
         this->fov = fov;
     }
 
+    void lookAt(QVector3D target);
+
     //update view and proj matrices
     void updateCameraMatrices()
     {

--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -135,8 +135,8 @@ void MeshNode::submitRenderItems()
             renderItem->worldMatrix = this->globalTransform;
             renderItem->cullable = true;
             //renderItem->boundingSphere.pos = this->globalTransform.column(3).toVector3D() + mesh->boundingSphere->pos;
-            renderItem->boundingSphere.pos = this->globalTransform * mesh->boundingSphere->pos;
-            renderItem->boundingSphere.radius = mesh->boundingSphere->radius * getMeshRadius();
+            renderItem->boundingSphere.pos = this->globalTransform * mesh->boundingSphere.pos;
+            renderItem->boundingSphere.radius = mesh->boundingSphere.radius * getMeshRadius();
 
         if (!!material) {
             renderItem->renderLayer = material->renderLayer;

--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -160,6 +160,14 @@ float MeshNode::getMeshRadius()
     return qMax(qMax(scaleX, scaleY), scaleZ);
 }
 
+BoundingSphere MeshNode::getTransformedBoundingSphere()
+{
+    BoundingSphere boundingSphere;
+    boundingSphere.pos = this->globalTransform * mesh->boundingSphere.pos;
+    boundingSphere.radius = mesh->boundingSphere.radius * getMeshRadius();
+    return boundingSphere;
+}
+
 /*
 void MeshNode::updateAnimation(float time)
 {

--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -134,7 +134,8 @@ void MeshNode::submitRenderItems()
         //else
             renderItem->worldMatrix = this->globalTransform;
             renderItem->cullable = true;
-            renderItem->boundingSphere.pos = this->globalTransform.column(3).toVector3D();
+            //renderItem->boundingSphere.pos = this->globalTransform.column(3).toVector3D() + mesh->boundingSphere->pos;
+            renderItem->boundingSphere.pos = this->globalTransform * mesh->boundingSphere->pos;
             renderItem->boundingSphere.radius = mesh->boundingSphere->radius * getMeshRadius();
 
         if (!!material) {

--- a/src/irisgl/src/scenegraph/meshnode.h
+++ b/src/irisgl/src/scenegraph/meshnode.h
@@ -92,6 +92,7 @@ public:
     SceneNodePtr createDuplicate() override;
     virtual void submitRenderItems() override;
     float getMeshRadius();
+    BoundingSphere getTransformedBoundingSphere();
 
     //void updateAnimation(float time) override;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -646,6 +646,8 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
     settings->setValue("geometry", saveGeometry());
     settings->setValue("windowState", saveState());
+
+    ThumbnailGenerator::getSingleton()->shutdown();
 }
 
 void MainWindow::setupFileMenu()

--- a/src/widgets/assetpickerwidget.cpp
+++ b/src/widgets/assetpickerwidget.cpp
@@ -38,7 +38,7 @@ AssetPickerWidget::~AssetPickerWidget()
 
 void AssetPickerWidget::populateWidget(QString filter)
 {
-    for (auto asset : AssetManager::assets) {
+    for (auto asset : AssetManager::getAssets()) {
         QPixmap pixmap;
 
         if (asset->type == type) {

--- a/src/widgets/assetwidget.cpp
+++ b/src/widgets/assetwidget.cpp
@@ -217,8 +217,10 @@ void AssetWidget::addItem(const QString &asset)
             item->setIcon(QIcon(":/icons/google-drive-file.svg"));
             //qDebug()<<file.absoluteFilePath();
             auto asset = AssetManager::getAssetByPath(file.absoluteFilePath());
-            if (asset!=nullptr)
-                item->setIcon(QIcon(asset->thumbnail));
+            if (asset!=nullptr) {
+                if (!asset->thumbnail.isNull())
+                    item->setIcon(QIcon(asset->thumbnail));
+            }
         } else if (file.suffix() == "shader") {
             //type = AssetType::Shader;
             item->setIcon(QIcon(":/icons/google-drive-file.svg"));
@@ -587,6 +589,12 @@ void AssetWidget::onThumbnailResult(ThumbnailResult* result)
         if (asset->path == result->id) {
             //qDebug()<<asset->path;
             asset->thumbnail = QPixmap::fromImage(result->thumbnail);
+
+            // find item and update its icon
+            auto items = ui->assetView->findItems(asset->fileName, Qt::MatchExactly);
+            if (items.count() > 0) {
+                items[0]->setIcon(asset->thumbnail);
+            }
 
             //auto thumb = ThumbnailManager::createThumbnail(":/icons/google-drive-file.svg", 128, 128);
             //asset->thumbnail = QPixmap::fromImage(*thumb->thumb);

--- a/src/widgets/assetwidget.h
+++ b/src/widgets/assetwidget.h
@@ -69,12 +69,14 @@ protected slots:
     void importAssetB();
     void importAsset(const QStringList &path);
 
-    void onThumbnailResult(const ThumbnailResult& result);
+    void onThumbnailResult(ThumbnailResult* result);
 
 private:
     Ui::AssetWidget *ui;
     AssetItem assetItem;
     QPoint startPos;
+
+    QString currentPath;
 };
 
 #endif // ASSETWIDGET_H

--- a/src/widgets/assetwidget.h
+++ b/src/widgets/assetwidget.h
@@ -11,6 +11,7 @@ namespace Ui {
 #include <QFileDialog>
 
 #include "../io/assetmanager.h"
+#include "../editor/thumbnailgenerator.h"
 
 // TODO - https://stackoverflow.com/questions/19465812/how-can-i-insert-qdockwidget-as-tab
 
@@ -67,6 +68,8 @@ protected slots:
     void createFolder();
     void importAssetB();
     void importAsset(const QStringList &path);
+
+    void onThumbnailResult(const ThumbnailResult& result);
 
 private:
     Ui::AssetWidget *ui;

--- a/src/widgets/propertywidgets/materialpropertywidget.cpp
+++ b/src/widgets/propertywidgets/materialpropertywidget.cpp
@@ -48,7 +48,7 @@ void MaterialPropertyWidget::setSceneNode(QSharedPointer<iris::SceneNode> sceneN
         if (shaderFile.exists()) {
             material->generate(shaderFile.absoluteFilePath());
         } else {
-            for (auto asset : AssetManager::assets) {
+            for (auto asset : AssetManager::getAssets()) {
                 if (asset->type == AssetType::Shader) {
                     if (asset->fileName == material->getName() + ".shader") {
                         material->generate(asset->path, true);
@@ -95,7 +95,7 @@ void MaterialPropertyWidget::setupShaderSelector()
         materialSelector->addItem(QFileInfo(shaderName).baseName());
     }
 
-    for (auto asset : AssetManager::assets) {
+    for (auto asset : AssetManager::getAssets()) {
         if (asset->type == AssetType::Shader) {
             materialSelector->addItem(QFileInfo(asset->fileName).baseName());
         }

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -104,6 +104,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
                                                           QVector3D(   0, 0, -100));
 
     setAcceptDrops(true);
+
+    thumbGen = nullptr;
 }
 
 void SceneViewWidget::resetEditorCam()
@@ -280,7 +282,8 @@ void SceneViewWidget::initializeGL()
 
     emit initializeGraphics(this, this);
 
-    auto thumbGen = new ThumbnialGenerator();
+    //thumbGen = new ThumbnialGenerator();
+    thumbGen = ThumbnailGenerator::getSingleton();
 
     auto timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -55,6 +55,8 @@ For more information see the LICENSE file
 #include "../irisgl/src/graphics/utils/linemeshbuilder.h"
 #include "../irisgl/src/materials/colormaterial.h"
 
+#include "../editor/thumbnailgenerator.h"
+
 SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 {
     dragging = false;
@@ -277,6 +279,8 @@ void SceneViewWidget::initializeGL()
     screenshotRT->addTexture(screenshotTex);
 
     emit initializeGraphics(this, this);
+
+    auto thumbGen = new ThumbnialGenerator();
 
     auto timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));

--- a/src/widgets/sceneviewwidget.h
+++ b/src/widgets/sceneviewwidget.h
@@ -50,6 +50,7 @@ class RotationGizmo;
 class ScaleGizmo;
 
 class EditorData;
+class ThumbnailGenerator;
 
 enum class ViewportMode
 {
@@ -92,6 +93,8 @@ class SceneViewWidget : public QOpenGLWidget,
     iris::Texture2DPtr screenshotTex;
 public:
     iris::CameraNodePtr editorCam;
+
+    ThumbnailGenerator* thumbGen;
 
     explicit SceneViewWidget(QWidget *parent);
 


### PR DESCRIPTION
This branch adds a thumbnail renderer that generates thumbnails for 3d assets on a dedicated thread. It will try as best as possible to center the model in the thumbnail. Models will be rendered with textures, provided the texture is available in the location specified by the model's material. 

In debug mode on windows, it slows down loading and rendering of the scene. It runs smoothly otherwise.