### PR TITLE
Changed look of cursor in timeline

### DIFF
--- a/src/widgets/keyframewidget.cpp
+++ b/src/widgets/keyframewidget.cpp
@@ -147,8 +147,8 @@ void KeyFrameWidget::paintEvent(QPaintEvent *painter)
     }
 
     //cursor
-    auto cursorPen = QPen(QColor::fromRgb(142,45,197));
-    cursorPen.setWidth(3);
+    auto cursorPen = QPen(QColor::fromRgb(255, 255, 255));
+    cursorPen.setWidth(1);
     paint.setPen(cursorPen);
     auto cursorScreenPos = timeToPos(animWidgetData->cursorPosInSeconds);
     paint.drawLine(cursorScreenPos,0,cursorScreenPos,widgetHeight);

--- a/src/widgets/timelinewidget.cpp
+++ b/src/widgets/timelinewidget.cpp
@@ -35,8 +35,8 @@ TimelineWidget::TimelineWidget(QWidget* parent):
     itemColor = QColor::fromRgb(255,255,255);
 
     linePen = QPen(itemColor);
-    cursorPen = QPen(QColor::fromRgb(255,0,0));
-    cursorPen.setWidth(3);
+    cursorPen = QPen(QColor::fromRgb(255, 255, 255));
+    cursorPen.setWidth(1);
 
     setMouseTracking(true);
 
@@ -76,6 +76,8 @@ void TimelineWidget::paintEvent(QPaintEvent *painter)
     int widgetHeight = this->geometry().height();
 
     QPainter paint(this);
+    paint.setRenderHint(QPainter::Antialiasing);
+    paint.setRenderHint(QPainter::HighQualityAntialiasing);
 
     //black bg
     //paint.fillRect(0,0,widgetWidth,widgetHeight,bgColor);
@@ -131,8 +133,23 @@ void TimelineWidget::paintEvent(QPaintEvent *painter)
 
 
     //cursor
+    auto cursorX = timeToPos(animWidgetData->cursorPosInSeconds);
     paint.setPen(cursorPen);
-    paint.drawLine(timeToPos(animWidgetData->cursorPosInSeconds), 0, timeToPos(animWidgetData->cursorPosInSeconds), widgetHeight);
+    paint.drawLine(cursorX, 0, cursorX, widgetHeight);
+
+    // draw cursor's "handle"
+    int handleWidth = 16;
+    int halfHandleWidth = handleWidth/2;
+    int handleHeight = 8;
+
+    QPainterPath path;
+    path.moveTo(cursorX - halfHandleWidth, 0);
+    path.lineTo(cursorX + halfHandleWidth, 0);
+    path.lineTo(cursorX + halfHandleWidth, handleHeight);
+    path.lineTo(cursorX, handleHeight+5);
+    path.lineTo(cursorX - halfHandleWidth, handleHeight);
+    //path.lineTo();
+    paint.fillPath(path, QBrush(QColor(255, 255, 255)));
 }
 
 int TimelineWidget::timeToPos(float timeInSeconds)


### PR DESCRIPTION
Cursor now has a 'handle' rendered in the timeline widget.
The color was also changed to white.