### PR TITLE
Capped framerate at 60fps

### DIFF
--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -289,7 +289,7 @@ void SceneViewWidget::initializeGL()
 
     auto timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(update()));
-    timer->start();
+    timer->start(17);
 
     this->elapsedTimer->start();
 }


### PR DESCRIPTION
Fixed cpu over usage issue by setting the rendering timer to update at 17ms intervals (effectively capping the framerate at 60 fps).