### PR TITLE
Culling disabled for animated models

### DIFF
--- a/src/irisgl/src/scenegraph/meshnode.cpp
+++ b/src/irisgl/src/scenegraph/meshnode.cpp
@@ -133,7 +133,10 @@ void MeshNode::submitRenderItems()
         //}
         //else
             renderItem->worldMatrix = this->globalTransform;
-            renderItem->cullable = true;
+            if (mesh->hasSkeletalAnimations())
+                renderItem->cullable = false;
+            else
+                renderItem->cullable = true;
             //renderItem->boundingSphere.pos = this->globalTransform.column(3).toVector3D() + mesh->boundingSphere->pos;
             renderItem->boundingSphere.pos = this->globalTransform * mesh->boundingSphere.pos;
             renderItem->boundingSphere.radius = mesh->boundingSphere.radius * getMeshRadius();


### PR DESCRIPTION
Meshes with skeletal animations are animated on the gpu so their bounds cannot be calculated. For this reason, culling for animated models are disabled for now. 