### PR TITLE
Add option to hide/show fps I preferences

### DIFF
--- a/src/dialogs/preferences/worldsettings.cpp
+++ b/src/dialogs/preferences/worldsettings.cpp
@@ -12,6 +12,8 @@ For more information see the LICENSE file
 #include "ui_worldsettings.h"
 #include "../../core/settingsmanager.h"
 #include "../../constants.h"
+#include "../../uimanager.h"
+#include "../../widgets/sceneviewwidget.h"
 #include <QFileDialog>
 #include <QStandardPaths>
 
@@ -34,6 +36,9 @@ WorldSettings::WorldSettings(SettingsManager* settings) :
     connect(ui->projectDefault, SIGNAL(textChanged(QString)),
             this, SLOT(projectDirectoryChanged(QString)));
 
+    connect(ui->showFPS, SIGNAL(toggled(bool)),
+            this, SLOT(showFpsChanged(bool)));
+
     setupDirectoryDefaults();
     setupOutline();
 }
@@ -42,9 +47,11 @@ void WorldSettings::setupOutline()
 {
     outlineWidth = settings->getValue("outline_width", 6).toInt();
     outlineColor = settings->getValue("outline_color", "#3498db").toString();
+    showFps = settings->getValue("show_fps", true).toBool();
 
     ui->outlineWidth->setValue(outlineWidth);
     ui->outlineColor->setColor(outlineColor);
+    ui->showFPS->setChecked(showFps);
 }
 
 void WorldSettings::changeDefaultDirectory()
@@ -64,6 +71,13 @@ void WorldSettings::outlineColorChanged(QColor color)
 {
     settings->setValue("outline_color", color.name());
     outlineColor = color;
+}
+
+void WorldSettings::showFpsChanged(bool show)
+{
+    showFps = show;
+    if (UiManager::sceneViewWidget)
+        UiManager::sceneViewWidget->setShowFps(show);
 }
 
 void WorldSettings::projectDirectoryChanged(QString path)

--- a/src/dialogs/preferences/worldsettings.cpp
+++ b/src/dialogs/preferences/worldsettings.cpp
@@ -47,7 +47,7 @@ void WorldSettings::setupOutline()
 {
     outlineWidth = settings->getValue("outline_width", 6).toInt();
     outlineColor = settings->getValue("outline_color", "#3498db").toString();
-    showFps = settings->getValue("show_fps", true).toBool();
+    showFps = settings->getValue("show_fps", false).toBool();
 
     ui->outlineWidth->setValue(outlineWidth);
     ui->outlineColor->setColor(outlineColor);

--- a/src/dialogs/preferences/worldsettings.h
+++ b/src/dialogs/preferences/worldsettings.h
@@ -31,6 +31,7 @@ public:
     int outlineWidth;
     QColor outlineColor;
     QString defaultProjectDirectory;
+    bool showFps;
 
     void setupDirectoryDefaults();
     void setupOutline();
@@ -38,6 +39,7 @@ public:
 private slots:
     void outlineWidthChanged(double width);
     void outlineColorChanged(QColor color);
+    void showFpsChanged(bool show);
     void changeDefaultDirectory();
     void projectDirectoryChanged(QString path);
 

--- a/src/dialogs/preferences/worldsettings.ui
+++ b/src/dialogs/preferences/worldsettings.ui
@@ -186,6 +186,37 @@ QDoubleSpinBox::down-button:pressed {
      </item>
     </layout>
    </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Show FPS: </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBox">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/dialogs/preferences/worldsettings.ui
+++ b/src/dialogs/preferences/worldsettings.ui
@@ -196,7 +196,7 @@ QDoubleSpinBox::down-button:pressed {
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="checkBox">
+      <widget class="QCheckBox" name="showFPS">
        <property name="text">
         <string/>
        </property>

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -59,6 +59,12 @@ For more information see the LICENSE file
 #include "../irisgl/src/materials/colormaterial.h"
 
 #include "../editor/thumbnailgenerator.h"
+#include "../core/settingsmanager.h"
+
+void SceneViewWidget::setShowFps(bool value)
+{
+    showFps = value;
+}
 
 SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 {
@@ -108,6 +114,7 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
     thumbGen = nullptr;
 
     fontSize = 20;
+    showFps = SettingsManager::getDefaultManager()->getValue("show_fps", true).toBool();
 }
 
 void SceneViewWidget::resetEditorCam()
@@ -394,15 +401,17 @@ void SceneViewWidget::renderScene()
     }
 
     // render fps
-    float fps = 1.0 / dt;
-    float ms = 1000.f / fps;
     spriteBatch->begin();
-    spriteBatch->drawString(font,
-                            QString("%1ms (%2fps)")
-                                .arg(QString::number(ms, 'f', 1))
-                                .arg(QString::number(fps, 'f', 1)),
-                            QVector2D(8, 8),
-                            QColor(255, 255, 255));
+    if (showFps) {
+        float fps = 1.0 / dt;
+        float ms = 1000.f / fps;
+        spriteBatch->drawString(font,
+                                QString("%1ms (%2fps)")
+                                    .arg(QString::number(ms, 'f', 1))
+                                    .arg(QString::number(fps, 'f', 1)),
+                                QVector2D(8, 8),
+                                QColor(255, 255, 255));
+    }
     spriteBatch->end();
 
 }

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -114,7 +114,7 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
     thumbGen = nullptr;
 
     fontSize = 20;
-    showFps = SettingsManager::getDefaultManager()->getValue("show_fps", true).toBool();
+    showFps = SettingsManager::getDefaultManager()->getValue("show_fps", false).toBool();
 }
 
 void SceneViewWidget::resetEditorCam()

--- a/src/widgets/sceneviewwidget.h
+++ b/src/widgets/sceneviewwidget.h
@@ -97,6 +97,7 @@ class SceneViewWidget : public QOpenGLWidget, protected QOpenGLFunctions_3_2_Cor
     iris::SpriteBatchPtr spriteBatch;
     iris::FontPtr font;
     float fontSize;
+    bool showFps;
 public:
     iris::CameraNodePtr editorCam;
 
@@ -153,6 +154,8 @@ public:
     QImage takeScreenshot(int width=1920, int height=1080);
     bool getShowLightWires() const;
     void setShowLightWires(bool value);
+
+    void setShowFps(bool value);
 
 protected:
     void initializeGL();


### PR DESCRIPTION
Added an option in the preferences dialog that allows users to hide/show fps display in sceneview widget.