### PR TITLE
Animation Looping bugfix

### DIFF
--- a/src/widgets/animationwidget.cpp
+++ b/src/widgets/animationwidget.cpp
@@ -437,6 +437,8 @@ void AnimationWidget::addPropertyKey(QAction *action)
         break;
     }
 
+    animation->calculateAnimationLength();
+
     // recalc summary keys for this property
     ui->keylabelView->recalcPropertySummaryKeys(animProp->name);
 


### PR DESCRIPTION
Animations would loop incorrectly because its length wasnt being correctly calculated. The animation length is now recalculated when when a new key is added.