### PR TITLE
Scene cleanup

### DIFF
--- a/src/irisgl/src/scenegraph/scene.cpp
+++ b/src/irisgl/src/scenegraph/scene.cpp
@@ -263,4 +263,25 @@ void Scene::setOutlineColor(QColor color)
     outlineColor = color;
 }
 
+void Scene::cleanup()
+{
+    camera.clear();
+    rootNode.clear();
+    vrViewer.clear();
+
+    skyMesh.clear();
+    skyTexture.clear();
+    skyMaterial.clear();
+    delete skyRenderItem;
+
+    lights.clear();
+    meshes.clear();
+    particleSystems.clear();
+    viewers.clear();
+
+    delete geometryRenderList;
+    delete shadowRenderList;
+    delete gizmoRenderList;
+}
+
 }

--- a/src/irisgl/src/scenegraph/scene.h
+++ b/src/irisgl/src/scenegraph/scene.h
@@ -149,6 +149,8 @@ public:
      * @param color
      */
     void setOutlineColor(QColor color);
+
+    void cleanup();
 };
 
 }


### PR DESCRIPTION
Added a cleanup function to the Scene class. It should break the circular dependence that prevents the scene from being cleaned up automatically by the QSharedPointers that holds it a reference to it.