### PR TITLE
Viewer Controller for play mode

### DIFF
--- a/Jahshaka.pro
+++ b/Jahshaka.pro
@@ -114,7 +114,8 @@ SOURCES += src/main.cpp\
     src/widgets/itemgridwidget.cpp \
     src/dialogs/renameprojectdialog.cpp \
     src/editor/thumbnailgenerator.cpp \
-    src/widgets/mainwindowviewport.cpp
+    src/widgets/mainwindowviewport.cpp \
+    src/editor/viewercontroller.cpp
 
 HEADERS  += src/mainwindow.h \
     src/dialogs/renamelayerdialog.h \
@@ -219,7 +220,8 @@ HEADERS  += src/mainwindow.h \
     src/widgets/itemgridwidget.hpp \
     src/dialogs/renameprojectdialog.h \
     src/editor/thumbnailgenerator.h \
-    src/widgets/mainwindowviewport.h
+    src/widgets/mainwindowviewport.h \
+    src/editor/viewercontroller.h
 
 FORMS    += \
     src/dialogs/renamelayerdialog.ui \

--- a/src/editor/cameracontrollerbase.cpp
+++ b/src/editor/cameracontrollerbase.cpp
@@ -74,6 +74,11 @@ void CameraControllerBase::onMouseWheel(int val)
 
 }
 
+void CameraControllerBase::start()
+{
+    resetMouseStates();
+}
+
 void CameraControllerBase::resetMouseStates()
 {
     leftMouseDown = false;
@@ -82,6 +87,11 @@ void CameraControllerBase::resetMouseStates()
 }
 
 void CameraControllerBase::update(float dt)
+{
+
+}
+
+void CameraControllerBase::end()
 {
 
 }

--- a/src/editor/cameracontrollerbase.h
+++ b/src/editor/cameracontrollerbase.h
@@ -35,7 +35,9 @@ public:
     virtual void onMouseMove(int x,int y);
     virtual void onMouseWheel(int val);
 
+    virtual void start();
     virtual void update(float dt);
+    virtual void end();
 
     void resetMouseStates();
 

--- a/src/editor/viewercontroller.cpp
+++ b/src/editor/viewercontroller.cpp
@@ -1,0 +1,73 @@
+#include "viewercontroller.h"
+#include "cameracontrollerbase.h"
+#include "../irisgl/src/scenegraph/scenenode.h"
+#include "../irisgl/src/scenegraph/cameranode.h"
+#include "../irisgl/src/scenegraph/viewernode.h"
+
+
+void ViewerCameraController::setViewer(iris::ViewerNodePtr &value)
+{
+    viewer = value;
+}
+
+void ViewerCameraController::start()
+{
+    viewer->hide();
+
+    // capture cam transform
+    camPos = camera->getLocalPos();
+    camRot = camera->getLocalRot();
+}
+
+void ViewerCameraController::end()
+{
+    clearViewer();
+
+    // restore cam transform
+    camera->setLocalPos(camPos);
+    camera->setLocalRot(camRot);
+    camera->update(0);
+}
+
+void ViewerCameraController::clearViewer()
+{
+    viewer->show();
+    viewer.clear();
+}
+
+void ViewerCameraController::onMouseMove(int dx, int dy)
+{
+    if(rightMouseDown) {
+        this->yaw += dx/10.0f;
+        this->pitch += dy/10.0f;
+    }
+    updateCameraTransform();
+}
+
+void ViewerCameraController::onMouseWheel(int delta)
+{
+
+}
+
+void ViewerCameraController::updateCameraTransform()
+{
+    camera->setLocalPos(viewer->getGlobalPosition());
+
+    auto viewMat = viewer->getGlobalTransform().normalMatrix();
+    QQuaternion rot = QQuaternion::fromRotationMatrix(viewMat);
+    camera->setLocalRot(rot * QQuaternion::fromEulerAngles(pitch,yaw,0));
+    //camera->setLocalRot(QQuaternion::fromEulerAngles(pitch,yaw,0));
+    camera->update(0);
+}
+
+ViewerCameraController::ViewerCameraController()
+{
+    yaw = 0;
+    pitch = 0;
+}
+
+void ViewerCameraController::update(float dt)
+{
+    updateCameraTransform();
+}
+

--- a/src/editor/viewercontroller.h
+++ b/src/editor/viewercontroller.h
@@ -1,0 +1,35 @@
+#ifndef VIEWERCONTROLLER_H
+#define VIEWERCONTROLLER_H
+
+#include "../../../irisgl/src/irisglfwd.h"
+#include <QQuaternion>
+#include <QVector3D>
+#include "cameracontrollerbase.h"
+
+class ViewerCameraController : public CameraControllerBase
+{
+    iris::ViewerNodePtr viewer;
+    float pitch;
+    float yaw;
+
+    // pos and rot of editor camera before being assigned
+    // to this controller
+    QQuaternion camRot;
+    QVector3D camPos;
+
+public:
+
+    ViewerCameraController();
+
+    void update(float dt) override;
+    void onMouseMove(int dx,int dy) override;
+    void onMouseWheel(int delta) override;
+
+    void updateCameraTransform();
+    void setViewer(iris::ViewerNodePtr &value);
+    void start() override;
+    void end() override;
+    void clearViewer();
+};
+
+#endif // VIEWERCONTROLLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,7 @@ int main(int argc, char *argv[])
 
     Globals::appWorkingDir = QApplication::applicationDirPath();
     app.processEvents();
+    //app.setOverrideCursor( QCursor( Qt::BlankCursor ) );
 
     // Create our main app window but hide it at the same time while showing the EDITOR first
     // Set the attribute to render invisible while running as normal then hiding it after

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -664,6 +664,8 @@ void MainWindow::switchSpace(WindowSpaces space)
             ui->player_menu->setStyleSheet(unselectedMenu);
             ui->player_menu->setDisabled(false);
             ui->player_menu->setCursor(Qt::PointingHandCursor);
+
+            playSceneBtn->show();
             break;
         }
 
@@ -678,6 +680,8 @@ void MainWindow::switchSpace(WindowSpaces space)
             ui->player_menu->setStyleSheet(selectedMenu);
             ui->player_menu->setDisabled(false);
             ui->player_menu->setCursor(Qt::PointingHandCursor);
+
+            playSceneBtn->hide();
             break;
         }
         default: break;

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -365,24 +365,30 @@ void SceneViewWidget::renderScene()
         if (UiManager::sceneMode != SceneMode::PlayMode && showLightWires) addLightShapesToScene();
 
         // render thumbnail to texture
-        if (!!selectedNode && selectedNode->getSceneNodeType() == iris::SceneNodeType::Viewer) {
-            viewerCamera->setLocalTransform(selectedNode->getGlobalTransform());
-            viewerCamera->update(0); // update transformation of camera
+        if (!playScene && !!selectedNode) {
+            if (selectedNode->getSceneNodeType() == iris::SceneNodeType::Viewer) {
+                viewerCamera->setLocalTransform(selectedNode->getGlobalTransform());
+                viewerCamera->update(0); // update transformation of camera
 
-            // resize render target to fix aspect ratio
-            viewerRT->resize(this->width(), this->height(), true);
+                // resize render target to fix aspect ratio
+                viewerRT->resize(this->width(), this->height(), true);
 
-            renderer->renderSceneToRenderTarget(viewerRT, viewerCamera);
+                renderer->renderSceneToRenderTarget(viewerRT, viewerCamera);
 
-            // restore viewer visibility state
-            if (viewerVisible) {
-                selectedNode->show();
+                // restore viewer visibility state
+                if (viewerVisible) {
+                    selectedNode->show();
 
-                // let it show back in regular scene rendering mode
-                // i know this looks like a hack, but it'll
-                // have to do until we find a better way to do this
-                if (UiManager::sceneMode == SceneMode::EditMode && viewportMode == ViewportMode::Editor)
-                    selectedNode->submitRenderItems();
+                    // let it show back in regular scene rendering mode
+                    // i know this looks like a hack, but it'll
+                    // have to do until we find a better way to do this
+                    if (UiManager::sceneMode == SceneMode::EditMode && viewportMode == ViewportMode::Editor)
+                        selectedNode->submitRenderItems();
+                }
+            }
+            else {
+                if (viewerVisible)
+                    selectedNode->show();
             }
         }
 
@@ -392,15 +398,18 @@ void SceneViewWidget::renderScene()
             renderer->renderSceneVr(dt, viewport, UiManager::sceneMode == SceneMode::PlayMode);
         }
 
-        if (!!selectedNode && selectedNode->getSceneNodeType() == iris::SceneNodeType::Viewer) {
-            QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_2_Core>()->glClear(GL_DEPTH_BUFFER_BIT);
-            QMatrix4x4 mat;
-            mat.setToIdentity();
-            mat.translate(0.75, -0.75, 0);
-            mat.scale(0.2, 0.2, 0);
-            viewerTex->bind(0);
-            viewerQuad->matrix = mat;
-            viewerQuad->draw();
+        // dont show thumbnail in play mode
+        if (!playScene) {
+            if (!!selectedNode && selectedNode->getSceneNodeType() == iris::SceneNodeType::Viewer) {
+                QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_2_Core>()->glClear(GL_DEPTH_BUFFER_BIT);
+                QMatrix4x4 mat;
+                mat.setToIdentity();
+                mat.translate(0.75, -0.75, 0);
+                mat.scale(0.2, 0.2, 0);
+                viewerTex->bind(0);
+                viewerQuad->matrix = mat;
+                viewerQuad->draw();
+            }
         }
 
         this->updateScene();

--- a/src/widgets/sceneviewwidget.h
+++ b/src/widgets/sceneviewwidget.h
@@ -41,6 +41,7 @@ class QOpenGLShaderProgram;
 class CameraControllerBase;
 class EditorVrController;
 class OrbitalCameraController;
+class ViewerCameraController;
 class QElapsedTimer;
 class QTimer;
 
@@ -76,6 +77,7 @@ class SceneViewWidget : public QOpenGLWidget, protected QOpenGLFunctions_3_2_Cor
     CameraControllerBase* camController;
     EditorCameraController* defaultCam;
     OrbitalCameraController* orbitalCam;
+    ViewerCameraController* viewerCam;
     EditorVrController* vrCam;
 
     ViewportMode viewportMode;
@@ -117,6 +119,7 @@ public:
 
     //switches to the arc ball editor camera controller
     void setArcBallCameraMode();
+    void setCameraController();
 
     bool isVrSupported();
     void setViewportMode(ViewportMode viewportMode);
@@ -169,6 +172,8 @@ protected:
 
     // does raycasting from the mouse's screen position.
     void doGizmoPicking(const QPointF& point);
+    void setCameraController(CameraControllerBase* controller);
+    void restorePreviousCameraController();
 
 private slots:
     void paintGL();


### PR DESCRIPTION
When the scene is in play mode, the `ViewerCameraController` takes control of the camera so the user sees whatever the `ViewerNode` sees. It currently only uses the first viewer node added to the scene.