### PR TITLE
Final bug fixes before 0.4 alpha release

### DIFF
--- a/src/irisgl/src/graphics/forwardrenderer.h
+++ b/src/irisgl/src/graphics/forwardrenderer.h
@@ -124,6 +124,9 @@ private:
     void renderBillboardIcons(RenderData* renderData);
     void renderSelectedNode(RenderData* renderData, SceneNodePtr node);
 
+    void renderOutlineNode(RenderData* renderData, SceneNodePtr node);
+    void renderOutlineLine(RenderData* renderData, SceneNodePtr node);
+
     void createLineShader();
     void createParticleShader();
     void createEmitterShader();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -684,6 +684,7 @@ void MainWindow::switchSpace(WindowSpaces space)
             ui->player_menu->setCursor(Qt::PointingHandCursor);
 
             playSceneBtn->show();
+            UiManager::sceneMode = SceneMode::EditMode;
             break;
         }
 
@@ -699,6 +700,7 @@ void MainWindow::switchSpace(WindowSpaces space)
             ui->player_menu->setDisabled(false);
             ui->player_menu->setCursor(Qt::PointingHandCursor);
 
+            UiManager::sceneMode = SceneMode::PlayMode;
             playSceneBtn->hide();
             break;
         }
@@ -830,6 +832,7 @@ void MainWindow::setScene(QSharedPointer<iris::Scene> scene)
 
 void MainWindow::removeScene()
 {
+    sceneView->cleanup();
 }
 
 void MainWindow::setupPropertyUi()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -833,6 +833,7 @@ void MainWindow::setScene(QSharedPointer<iris::Scene> scene)
 void MainWindow::removeScene()
 {
     sceneView->cleanup();
+    sceneNodePropertiesWidget->setSceneNode(iris::SceneNodePtr());
 }
 
 void MainWindow::setupPropertyUi()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -684,6 +684,7 @@ void MainWindow::switchSpace(WindowSpaces space)
             ui->player_menu->setCursor(Qt::PointingHandCursor);
 
             playSceneBtn->show();
+            this->enterEditMode();
             UiManager::sceneMode = SceneMode::EditMode;
             break;
         }
@@ -702,6 +703,7 @@ void MainWindow::switchSpace(WindowSpaces space)
 
             UiManager::sceneMode = SceneMode::PlayMode;
             playSceneBtn->hide();
+            this->enterEditMode();
             break;
         }
         default: break;

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -974,6 +974,9 @@ EditorData* SceneViewWidget::getEditorData()
 
 void SceneViewWidget::startPlayingScene()
 {
+    if (!scene)
+        return;
+
     // switch controllers
     if (scene->viewers.count() > 0) {
         viewerCam->setViewer(scene->viewers[0]);
@@ -995,6 +998,10 @@ void SceneViewWidget::stopPlayingScene()
 {
     playScene = false;
     animTime = 0.0f;
+
+    if (!scene)
+        return;
+
     scene->updateSceneAnimation(0.0f);
 
     restorePreviousCameraController();

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -67,6 +67,18 @@ void SceneViewWidget::setShowFps(bool value)
     showFps = value;
 }
 
+void SceneViewWidget::cleanup()
+{
+    scene.reset();
+    selectedNode.reset();
+    translationGizmo->setLastSelectedNode(iris::SceneNodePtr());
+    rotationGizmo->setLastSelectedNode(iris::SceneNodePtr());
+    scaleGizmo->setLastSelectedNode(iris::SceneNodePtr());
+
+    renderer->setScene(iris::ScenePtr());
+    renderer->setSelectedSceneNode(iris::SceneNodePtr());
+}
+
 SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 {
     QSurfaceFormat format;

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -252,7 +252,10 @@ void SceneViewWidget::setScene(iris::ScenePtr scene)
 void SceneViewWidget::setSelectedNode(iris::SceneNodePtr sceneNode)
 {
     selectedNode = sceneNode;
-    renderer->setSelectedSceneNode(sceneNode);
+    if (sceneNode == scene->getRootNode())
+        renderer->setSelectedSceneNode(iris::SceneNodePtr());
+    else
+        renderer->setSelectedSceneNode(sceneNode);
 
     if (viewportGizmo != nullptr) {
         viewportGizmo->setLastSelectedNode(sceneNode);

--- a/src/widgets/sceneviewwidget.h
+++ b/src/widgets/sceneviewwidget.h
@@ -161,6 +161,8 @@ public:
 
     void setShowFps(bool value);
 
+    void cleanup();
+
 protected:
     void initializeGL();
     bool eventFilter(QObject *obj, QEvent *event);


### PR DESCRIPTION
Fixed outline rendering
Property widget now cleared when a new scene is selected (fixes bug of property widget still referencing previous scene)
Fixed animation bug when switching between desktop and editor mode