### PR TITLE
Breakpad Integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "irisgl/src/assimp"]
 	path = irisgl/src/assimp
 	url = https://github.com/assimp/assimp.git
+[submodule "thirdparty/breakpad/breakpad"]
+	path = thirdparty/breakpad/breakpad
+	url = https://chromium.googlesource.com/breakpad/breakpad

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/assimp/assimp.git
 [submodule "thirdparty/breakpad/breakpad"]
 	path = thirdparty/breakpad/breakpad
-	url = https://chromium.googlesource.com/breakpad/breakpad
+	url = git@github.com:jahshaka/breakpad.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/irisgl)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/breakpad)
 
 set(SRCS
     src/main.cpp
@@ -306,14 +307,20 @@ endif()
 # Also note MSVC build path is different from GNU in that it containts the build type
 set_target_properties(IrisGL PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set_target_properties(assimp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_target_properties(breakpad PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_executable(${CMAKE_PROJECT_NAME} src/main.cpp ${SRCS} ${HEADERS_moc} ${QRCS})
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC src irisgl/src irisgl/src/assimp/include/ irisgl/src/libovr/include/)
-target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets IrisGL ${OPENGL_LIBRARIES})
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
+															src
+															irisgl/src
+															irisgl/src/assimp/include/
+															irisgl/src/libovr/include/
+															thirdparty/breakpad/breakpad/src)
+target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets IrisGL breakpad ${OPENGL_LIBRARIES})
 
 include(CopyResources)
 include(CopyDependencies)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,11 @@ else()
     set(DestDir ${CMAKE_BINARY_DIR}/bin)
 endif()
 
+# only enable breakpad on windows platforms using msvc for now
+if(WIN32)
+	add_definitions("-DUSE_BREAKPAD")
+endif()
+
 # For convenience, put the shared files built from IrisGL along with the final binary
 # Also note MSVC build path is different from GNU in that it containts the build type
 set_target_properties(IrisGL PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/irisgl)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/breakpad)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/crash_handler)
 
 set(SRCS
     src/main.cpp
@@ -225,6 +226,7 @@ set(HEADERS
     src/widgets/assetviewer.h
     src/widgets/assetviewgrid.h
     src/widgets/assetgriditem.h
+	src/breakpad/breakpad.h
 )
 
 # Todo - trim these down to nothing eventually
@@ -308,6 +310,7 @@ endif()
 set_target_properties(IrisGL PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set_target_properties(assimp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set_target_properties(breakpad PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set_target_properties(crash_handler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/irisgl)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/breakpad)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/crash_handler)
 
 set(SRCS
     src/main.cpp
@@ -274,6 +272,10 @@ set(FORMS
     src/dialogs/donate.ui
 )
 
+set(LIBS Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets IrisGL ${OPENGL_LIBRARIES})
+
+include(IncludeBreakpad)
+
 qt5_wrap_cpp(HEADERS_moc ${HEADERS})
 qt5_wrap_ui(UI_moc ${FORMS})
 
@@ -305,17 +307,10 @@ else()
     set(DestDir ${CMAKE_BINARY_DIR}/bin)
 endif()
 
-# only enable breakpad on windows platforms using msvc for now
-if(WIN32)
-	add_definitions("-DUSE_BREAKPAD")
-endif()
-
 # For convenience, put the shared files built from IrisGL along with the final binary
 # Also note MSVC build path is different from GNU in that it containts the build type
 set_target_properties(IrisGL PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set_target_properties(assimp PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set_target_properties(breakpad PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set_target_properties(crash_handler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -326,9 +321,10 @@ target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC
 															src
 															irisgl/src
 															irisgl/src/assimp/include/
-															irisgl/src/libovr/include/
+                                                                                                                        irisgl/src/libovr/Include/
 															thirdparty/breakpad/breakpad/src)
-target_link_libraries(${CMAKE_PROJECT_NAME} Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets IrisGL breakpad ${OPENGL_LIBRARIES})
+target_link_libraries(${CMAKE_PROJECT_NAME} ${LIBS})
 
 include(CopyResources)
 include(CopyDependencies)
+

--- a/cmake/IncludeBreakpad.cmake
+++ b/cmake/IncludeBreakpad.cmake
@@ -1,7 +1,7 @@
 set(USE_BREAKPAD FALSE)
 
 # only enable breakpad on windows platforms using msvc for now
-if(WIN32 OR LINUX)
+if(WIN32 OR UNIX)
 	set(USE_BREAKPAD TRUE)
 endif()
 

--- a/cmake/IncludeBreakpad.cmake
+++ b/cmake/IncludeBreakpad.cmake
@@ -1,7 +1,7 @@
 set(USE_BREAKPAD FALSE)
 
 # only enable breakpad on windows platforms using msvc for now
-if(WIN32 OR UNIX)
+if(WIN32 OR (UNIX AND NOT APPLE))
 	set(USE_BREAKPAD TRUE)
 endif()
 

--- a/cmake/IncludeBreakpad.cmake
+++ b/cmake/IncludeBreakpad.cmake
@@ -1,0 +1,2 @@
+set(USE_BREAKPAD FALSE)
+

--- a/cmake/IncludeBreakpad.cmake
+++ b/cmake/IncludeBreakpad.cmake
@@ -1,2 +1,23 @@
 set(USE_BREAKPAD FALSE)
 
+# only enable breakpad on windows platforms using msvc for now
+if(WIN32 OR LINUX)
+	set(USE_BREAKPAD TRUE)
+endif()
+
+if (USE_BREAKPAD)
+	add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/breakpad)
+	add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/crash_handler)
+
+	set(HEADERS
+		${HEADERS}
+		src/breakpad/breakpad.h)
+
+	add_definitions("-DUSE_BREAKPAD")
+
+	set_target_properties(breakpad PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+	set_target_properties(crash_handler PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+	set(LIBS ${LIBS} breakpad)
+
+endif()

--- a/crash_handler/CMakeLists.txt
+++ b/crash_handler/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 project(crash_handler)
 
-find_package(Qt5 REQUIRED COMPONENTS Concurrent Widgets Sql Svg)
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED True)
+
+find_package(Qt5 REQUIRED COMPONENTS Concurrent Widgets Sql Svg Network)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -14,4 +17,4 @@ qt5_wrap_cpp(HEADERS_moc ${HEADERS})
 qt5_wrap_ui(UI_moc ${FORMS})
 
 add_executable(crash_handler main.cpp ${SRCS} ${HEADERS_moc})
-target_link_libraries(crash_handler Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets breakpad)
+target_link_libraries(crash_handler Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets Qt5::Network breakpad)

--- a/crash_handler/CMakeLists.txt
+++ b/crash_handler/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+project(crash_handler)
+
+find_package(Qt5 REQUIRED COMPONENTS Concurrent Widgets Sql Svg)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(SRCS crashreportdialog.cpp)
+set(HEADERS crashreportdialog.h)
+set(FORMS crashreportdialog.ui)
+
+qt5_wrap_cpp(HEADERS_moc ${HEADERS})
+qt5_wrap_ui(UI_moc ${FORMS})
+
+add_executable(crash_handler main.cpp ${SRCS} ${HEADERS_moc})
+target_link_libraries(crash_handler Qt5::Concurrent Qt5::Sql Qt5::Svg Qt5::Widgets breakpad)

--- a/crash_handler/crashreportdialog.cpp
+++ b/crash_handler/crashreportdialog.cpp
@@ -1,7 +1,7 @@
 #include "crashreportdialog.h"
 #include "ui_crashreportdialog.h"
 #if defined(Q_OS_WIN32)
-#include "client\windows\handler\exception_handler.h"
+#include "client\windows\sender\crash_report_sender.h"
 #elif defined(Q_OS_LINUX)
 #include "common/linux/google_crashdump_uploader.h"
 #endif

--- a/crash_handler/crashreportdialog.cpp
+++ b/crash_handler/crashreportdialog.cpp
@@ -25,6 +25,8 @@
 #include <QFile>
 #include <QStandardPaths>
 
+#define SERVER_URL L"http://breakpad.jahshaka.com/crashreports"
+
 CrashReportDialog::CrashReportDialog(QWidget* parent):
 	QDialog(parent),
 	ui(new Ui::CrashReportDialog)
@@ -77,7 +79,7 @@ void CrashReportDialog::onSend()
 	progress.setWindowModality(Qt::WindowModal);
 	progress.setValue(2);
 
-	google_breakpad::ReportResult r = sender.SendCrashReport(L"http://breakpad.jahshaka.com/crashreports", params, files, 0);
+	google_breakpad::ReportResult r = sender.SendCrashReport(SERVER_URL, params, files, 0);
 
 	progress.setValue(3);
 	QMessageBox msg;
@@ -90,7 +92,7 @@ void CrashReportDialog::onSend()
 #elif defined(Q_OS_LINUX)
 
     QNetworkAccessManager* manager = new QNetworkAccessManager();
-    QUrl url("http://breakpad.jahshaka.com/crashreports");
+    QUrl url(SERVER_URL);
     QUrlQuery query;
 
 

--- a/crash_handler/crashreportdialog.cpp
+++ b/crash_handler/crashreportdialog.cpp
@@ -1,0 +1,77 @@
+#include "crashreportdialog.h"
+#include "ui_crashreportdialog.h"
+#include "client\windows\handler\exception_handler.h"
+#include "client\windows\sender\crash_report_sender.h"
+
+#include <QProgressDialog>
+#include <QTextEdit>
+#include <QThread>
+#include <QDebug>
+#include <QMessageBox>
+
+#include <map>
+#include <string>
+
+CrashReportDialog::CrashReportDialog(QWidget* parent):
+	QDialog(parent),
+	ui(new Ui::CrashReportDialog)
+{
+	ui->setupUi(this);
+
+	//ui->crashCheck->hide();
+	ui->crashCheck->setChecked(false);
+	ui->crashCheck->setEnabled(false);
+
+	connect(ui->sendButton, SIGNAL(clicked()), this, SLOT(onSend()));
+	connect(ui->cancelButton, SIGNAL(clicked()), this, SLOT(onCancel()));
+}
+
+void CrashReportDialog::setCrashLogPath(QString path)
+{
+	logPath = path;
+	ui->crashCheck->setChecked(true);
+	ui->crashCheck->setEnabled(true);
+	ui->crashCheck->show();
+}
+
+void CrashReportDialog::setVersion(QString ver)
+{
+	version = ver;
+}
+
+void CrashReportDialog::onCancel()
+{
+	this->close();
+}
+
+void CrashReportDialog::onSend()
+{
+	//qDebug() << "sending report";
+	google_breakpad::CrashReportSender sender(L"crash.checkpoint");
+
+	std::map<std::wstring, std::wstring> params;
+	params[L"text"] = ui->textEdit->toPlainText().toStdWString();
+	params[L"prod"] = L"Jahshaka";
+	params[L"ver"] = version.toStdWString();
+
+	// Finally, send a report
+	std::map<std::wstring, std::wstring> files;
+	if (ui->crashCheck->checked())
+		files[std::wstring(L"upload_file_minidump")] = logPath.toStdWString();
+
+	QProgressDialog progress("Uploading Crash Report", "Cancel", 0, 3, this);
+	progress.setWindowModality(Qt::WindowModal);
+	progress.setValue(2);
+
+	google_breakpad::ReportResult r = sender.SendCrashReport(L"http://breakpad.jahshaka.com/crashreports", params, files, 0);
+
+	progress.setValue(3);
+	QMessageBox msg;
+	if (r == google_breakpad::RESULT_SUCCEEDED)
+		msg.setText("Report sent successfully!");
+	else
+		msg.setText("Failed to send report!");
+	msg.exec();
+
+	this->close();
+}

--- a/crash_handler/crashreportdialog.cpp
+++ b/crash_handler/crashreportdialog.cpp
@@ -23,6 +23,7 @@
 #include <QHttpPart>
 #include <QUrlQuery>
 #include <QFile>
+#include <QStandardPaths>
 
 CrashReportDialog::CrashReportDialog(QWidget* parent):
 	QDialog(parent),
@@ -59,9 +60,8 @@ void CrashReportDialog::onCancel()
 void CrashReportDialog::onSend()
 {
 #if defined(Q_OS_WIN32)
-
-	//qDebug() << "sending report";
-    google_breakpad::CrashReportSender sender(L"crash.checkpoint");
+	QString path = QStandardPaths::writableLocation(QStandardPaths::TempLocation) + QStringLiteral("crash.checkpoint");
+    google_breakpad::CrashReportSender sender(path.toStdWString());
 
 	std::map<std::wstring, std::wstring> params;
 	params[L"text"] = ui->textEdit->toPlainText().toStdWString();

--- a/crash_handler/crashreportdialog.cpp
+++ b/crash_handler/crashreportdialog.cpp
@@ -119,7 +119,10 @@ void CrashReportDialog::onSend()
         } else {
             qDebug()<<"success";
         }
+        if(file->exists() && file->isOpen())
+            file->close();
 
+        file->deleteLater();
         this->close();
     } );
 

--- a/crash_handler/crashreportdialog.cpp
+++ b/crash_handler/crashreportdialog.cpp
@@ -56,7 +56,7 @@ void CrashReportDialog::onSend()
 
 	// Finally, send a report
 	std::map<std::wstring, std::wstring> files;
-	if (ui->crashCheck->checked())
+	if (ui->crashCheck->isChecked())
 		files[std::wstring(L"upload_file_minidump")] = logPath.toStdWString();
 
 	QProgressDialog progress("Uploading Crash Report", "Cancel", 0, 3, this);

--- a/crash_handler/crashreportdialog.h
+++ b/crash_handler/crashreportdialog.h
@@ -1,0 +1,29 @@
+#ifndef CRASHREPORTDIALOG_H
+#define CRASHREPORTDIALOG_H
+
+#include <QDialog>
+#include <QString>
+
+class QWidget;
+
+namespace Ui {
+	class CrashReportDialog;
+}
+
+class CrashReportDialog : public QDialog
+{
+	Q_OBJECT
+
+	Ui::CrashReportDialog* ui;
+	QString logPath;
+	QString version;
+public:
+	CrashReportDialog(QWidget* parent);
+	void setCrashLogPath(QString path);
+	void setVersion(QString ver);
+
+private slots:
+	void onCancel();
+	void onSend();
+};
+#endif // !CRASHREPORTDIALOG_H

--- a/crash_handler/crashreportdialog.h
+++ b/crash_handler/crashreportdialog.h
@@ -26,4 +26,4 @@ private slots:
 	void onCancel();
 	void onSend();
 };
-#endif // !CRASHREPORTDIALOG_H
+#endif // CRASHREPORTDIALOG_H

--- a/crash_handler/crashreportdialog.ui
+++ b/crash_handler/crashreportdialog.ui
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CrashReportDialog</class>
+ <widget class="QDialog" name="CrashReportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>609</width>
+    <height>445</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Jahshaka has crashed!</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Maybe you could help us fix what was broken. What were you doing before the crash?</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="crashCheck">
+     <property name="text">
+      <string>Send crash dump</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="textEdit"/>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>50</height>
+      </size>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>All data from crash reports are anonymous</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>135</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="cancelButton">
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="sendButton">
+        <property name="text">
+         <string>Send Report</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/crash_handler/crashreportdialog.ui
+++ b/crash_handler/crashreportdialog.ui
@@ -14,7 +14,10 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Jahshaka has crashed!</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;Jahshaka has crashed!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>

--- a/crash_handler/main.cpp
+++ b/crash_handler/main.cpp
@@ -1,0 +1,20 @@
+#include <QApplication>
+#include "crashreportdialog.h"
+
+int main(int argc, char** argv)
+{
+	QApplication app(argc, argv);
+
+	CrashReportDialog crashReporter(nullptr);
+
+	// second parameter is the path to the log file
+	if (argc > 1)
+		crashReporter.setCrashLogPath(QString(argv[1]));
+
+	// third parameter is the version
+	if (argc > 2)
+		crashReporter.setVersion(QString(argv[2]));
+	crashReporter.show();
+
+	return app.exec();
+}

--- a/crash_handler/main.cpp
+++ b/crash_handler/main.cpp
@@ -4,6 +4,7 @@
 int main(int argc, char** argv)
 {
 	QApplication app(argc, argv);
+
     app.setApplicationDisplayName("Jahshaka Crash Handler");
     app.setApplicationName("Jahshaka Crash Handler");
 

--- a/crash_handler/main.cpp
+++ b/crash_handler/main.cpp
@@ -4,6 +4,8 @@
 int main(int argc, char** argv)
 {
 	QApplication app(argc, argv);
+    app.setApplicationDisplayName("Jahshaka Crash Handler");
+    app.setApplicationName("Jahshaka Crash Handler");
 
 	CrashReportDialog crashReporter(nullptr);
 

--- a/irisgl/src/core/irisutils.h
+++ b/irisgl/src/core/irisutils.h
@@ -26,11 +26,11 @@ public:
         QDir basePath = QDir(QCoreApplication::applicationDirPath());
     // #if defined(WIN32) && defined(QT_DEBUG)
     //     basePath.cdUp();
-    // #elif defined(Q_OS_MAC)
-    //     basePath.cdUp();
-    //     basePath.cdUp();
-    //     basePath.cdUp();
-    // #endif
+		#if defined(Q_OS_MAC)
+			basePath.cdUp();
+			basePath.cdUp();
+			basePath.cdUp();
+		#endif
         auto path = QDir::cleanPath(basePath.absolutePath() + QDir::separator() + relToApp);
         return path;
     }

--- a/src/breakpad/breakpad.h
+++ b/src/breakpad/breakpad.h
@@ -32,7 +32,7 @@ bool JahshakaBreakpadCallback(const wchar_t* dump_dir,
 	QStringList args;
 	args << QString::fromWCharArray(filename.c_str());
 	args << Constants::CONTENT_VERSION;
-	proc->start("crash_handler.exe", args);
+	proc->startDetached("crash_handler.exe", args);
     delete proc;
 
 	return true;

--- a/src/breakpad/breakpad.h
+++ b/src/breakpad/breakpad.h
@@ -1,0 +1,38 @@
+#include "client\windows\handler\exception_handler.h"
+#include "client\windows\sender\crash_report_sender.h"
+#include "../constants.h"
+#include <string>
+#include <qdebug>
+#include <QProcess>
+#include <QStringList>
+
+
+bool JahshakaBreakpadCallback(const wchar_t* dump_dir,
+	const wchar_t* minidump_id,
+	void* context,
+	EXCEPTION_POINTERS* exinfo,
+	MDRawAssertionInfo* assertion,
+	bool succeeded)
+{
+	qDebug() << "crash captured";
+	std::wstring filename = dump_dir;
+	filename += L"\\";
+	filename += minidump_id;
+	filename += L".dmp";
+
+	auto proc = new QProcess();
+	QStringList args;
+	args << QString::fromWCharArray(filename.c_str());
+	args << Constants::CONTENT_VERSION;
+	proc->start("crash_handler.exe", args);
+
+	return true;
+}
+
+void initializeBreakpad()
+{
+	std::wstring path = qApp->applicationDirPath().toStdWString();
+	auto handler = new google_breakpad::ExceptionHandler(path, /*FilterCallback*/ 0,
+		JahshakaBreakpadCallback, /*context*/ 0,
+		google_breakpad::ExceptionHandler::HANDLER_ALL);
+}

--- a/src/breakpad/breakpad.h
+++ b/src/breakpad/breakpad.h
@@ -54,14 +54,14 @@ bool DumpCallback(const google_breakpad::MinidumpDescriptor& descriptor,
 
 void initializeBreakpad()
 {
-	std::wstring path = qApp->applicationDirPath().toStdWString();
+    QString path = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
 
 #if defined(Q_OS_WIN32)
-	auto handler = new google_breakpad::ExceptionHandler(path, 0,
+    auto handler = new google_breakpad::ExceptionHandler(path.toStdWString(), 0,
 		JahshakaBreakpadCallback, 0,
 		google_breakpad::ExceptionHandler::HANDLER_ALL);
 #elif defined(Q_OS_LINUX)
-    auto handler = new google_breakpad::ExceptionHandler(google_breakpad::MinidumpDescriptor(qApp->applicationDirPath().toStdString()),
+    auto handler = new google_breakpad::ExceptionHandler(google_breakpad::MinidumpDescriptor(path.toStdString()),
         0,
         DumpCallback,
         0,

--- a/src/breakpad/breakpad.h
+++ b/src/breakpad/breakpad.h
@@ -1,3 +1,7 @@
+#ifndef BREAKPAD_H
+#define BREAKPAD_H
+
+#ifdef USE_BREAKPAD
 #include "client\windows\handler\exception_handler.h"
 #include "client\windows\sender\crash_report_sender.h"
 #include "../constants.h"
@@ -32,7 +36,10 @@ bool JahshakaBreakpadCallback(const wchar_t* dump_dir,
 void initializeBreakpad()
 {
 	std::wstring path = qApp->applicationDirPath().toStdWString();
-	auto handler = new google_breakpad::ExceptionHandler(path, /*FilterCallback*/ 0,
-		JahshakaBreakpadCallback, /*context*/ 0,
+	auto handler = new google_breakpad::ExceptionHandler(path, 0,
+		JahshakaBreakpadCallback, 0,
 		google_breakpad::ExceptionHandler::HANDLER_ALL);
 }
+#endif
+
+#endif // BREAKPAD_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ For more information see the LICENSE file
 #include "globals.h"
 #include "constants.h"
 #ifdef USE_BREAKPAD
-#include "breakpad\breakpad.h"
+#include "breakpad/breakpad.h"
 #endif
 
 // Hints that a dedicated GPU should be used whenever possible

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,10 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
     QApplication::setDesktopSettingsAware(false);
     QApplication app(argc, argv);
+
+#ifdef USE_BREAKPAD
 	initializeBreakpad();
+#endif
 
     app.setWindowIcon(QIcon(":/images/logo.png"));
     app.setApplicationName("Jahshaka");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,9 @@ For more information see the LICENSE file
 #include "core/settingsmanager.h"
 #include "globals.h"
 #include "constants.h"
+#ifdef USE_BREAKPAD
 #include "breakpad\breakpad.h"
+#endif
 
 // Hints that a dedicated GPU should be used whenever possible
 // https://stackoverflow.com/a/39047129/991834

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ For more information see the LICENSE file
 #include "core/settingsmanager.h"
 #include "globals.h"
 #include "constants.h"
+#include "breakpad\breakpad.h"
 
 // Hints that a dedicated GPU should be used whenever possible
 // https://stackoverflow.com/a/39047129/991834
@@ -50,6 +51,8 @@ int main(int argc, char *argv[])
     QApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
     QApplication::setDesktopSettingsAware(false);
     QApplication app(argc, argv);
+	initializeBreakpad();
+
     app.setWindowIcon(QIcon(":/images/logo.png"));
     app.setApplicationName("Jahshaka");
 

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -202,8 +202,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 
     fontSize = 20;
     showFps = SettingsManager::getDefaultManager()->getValue("show_fps", false).toBool();
-	//iris::SceneNodePtr node;
-	//node->setLocalPos(QVector3D(0, 0, 0));
+    iris::SceneNodePtr node;
+    node->setLocalPos(QVector3D(0, 0, 0));
 }
 
 void SceneViewWidget::resetEditorCam()

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -202,8 +202,6 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 
     fontSize = 20;
     showFps = SettingsManager::getDefaultManager()->getValue("show_fps", false).toBool();
-    iris::SceneNodePtr node;
-    node->setLocalPos(QVector3D(0, 0, 0));
 }
 
 void SceneViewWidget::resetEditorCam()

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -202,6 +202,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 
     fontSize = 20;
     showFps = SettingsManager::getDefaultManager()->getValue("show_fps", false).toBool();
+	//iris::SceneNodePtr node;
+	//node->setLocalPos(QVector3D(0, 0, 0));
 }
 
 void SceneViewWidget::resetEditorCam()

--- a/thirdparty/breakpad/CMakeLists.txt
+++ b/thirdparty/breakpad/CMakeLists.txt
@@ -1,0 +1,22 @@
+project(breakpad)
+
+set(SRCS
+	breakpad/src/client/windows/handler/exception_handler.cc 
+	breakpad/src/client/windows/crash_generation/crash_generation_client.cc 
+	breakpad/src/common/windows/guid_string.cc
+
+	#crash sender
+	breakpad/src/client/windows/sender/crash_report_sender.cc
+	breakpad/src/common/windows/http_upload.cc
+)
+
+add_definitions("-DUNICODE")
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+
+add_library(breakpad SHARED ${SRCS})
+
+target_include_directories(breakpad PUBLIC
+    "${PROJECT_SOURCE_DIR}/breakpad/src/"
+)
+
+target_link_libraries(breakpad wininet.lib)

--- a/thirdparty/breakpad/CMakeLists.txt
+++ b/thirdparty/breakpad/CMakeLists.txt
@@ -1,6 +1,21 @@
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 project(breakpad)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(SRCS)
+set(LIBS)
+
 if (WIN32)
-	include (WindowsBreakpad)
+        include (WindowsBreakpad)
 endif (WIN32)
+
+add_library(breakpad SHARED ${SRCS})
+
+target_include_directories(breakpad PUBLIC
+    "${PROJECT_SOURCE_DIR}/breakpad/src/"
+)
+
+target_link_libraries(breakpad ${LIBS})
+add_definitions("-DUNICODE")
+

--- a/thirdparty/breakpad/CMakeLists.txt
+++ b/thirdparty/breakpad/CMakeLists.txt
@@ -3,12 +3,19 @@ project(breakpad)
 
 set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED True)
+
 set(SRCS)
 set(LIBS)
 
 if (WIN32)
         include (WindowsBreakpad)
 endif (WIN32)
+
+if ((UNIX) AND (NOT APPLE))
+    include (LinuxBreakpad)
+endif()
 
 add_library(breakpad SHARED ${SRCS})
 

--- a/thirdparty/breakpad/CMakeLists.txt
+++ b/thirdparty/breakpad/CMakeLists.txt
@@ -1,22 +1,6 @@
 project(breakpad)
 
-set(SRCS
-	breakpad/src/client/windows/handler/exception_handler.cc 
-	breakpad/src/client/windows/crash_generation/crash_generation_client.cc 
-	breakpad/src/common/windows/guid_string.cc
-
-	#crash sender
-	breakpad/src/client/windows/sender/crash_report_sender.cc
-	breakpad/src/common/windows/http_upload.cc
-)
-
-add_definitions("-DUNICODE")
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
-
-add_library(breakpad SHARED ${SRCS})
-
-target_include_directories(breakpad PUBLIC
-    "${PROJECT_SOURCE_DIR}/breakpad/src/"
-)
-
-target_link_libraries(breakpad wininet.lib)
+set (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+if (WIN32)
+	include (WindowsBreakpad)
+endif (WIN32)

--- a/thirdparty/breakpad/cmake/LinuxBreakpad.cmake
+++ b/thirdparty/breakpad/cmake/LinuxBreakpad.cmake
@@ -23,12 +23,5 @@ set(SRCS
     breakpad/src/common/linux/safe_readlink.cc 
     breakpad/src/common/linux/linux_libc_support.cc
     breakpad/src/common/linux/elf_core_dump.cc
-    #breakpad/src/common/linux/elf_core_dump.cc
-
-	#crash sender
-        #breakpad/src/common/linux/google_crashdump_uploader.cc
 )
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
-
 

--- a/thirdparty/breakpad/cmake/LinuxBreakpad.cmake
+++ b/thirdparty/breakpad/cmake/LinuxBreakpad.cmake
@@ -1,0 +1,34 @@
+set(SRCS
+        ${SRCS}
+    breakpad/src/client/minidump_file_writer.cc
+    breakpad/src/common/string_conversion.cc
+    breakpad/src/common/convert_UTF.c
+    breakpad/src/common/md5.cc
+
+    breakpad/src/client/linux/log/log.cc 
+    breakpad/src/client/linux/crash_generation/crash_generation_client.cc 
+    breakpad/src/client/linux/dump_writer_common/thread_info.cc 
+    breakpad/src/client/linux/dump_writer_common/ucontext_reader.cc 
+    breakpad/src/client/linux/microdump_writer/microdump_writer.cc 
+    breakpad/src/client/linux/minidump_writer/linux_dumper.cc 
+    breakpad/src/client/linux/minidump_writer/linux_core_dumper.cc 
+    breakpad/src/client/linux/minidump_writer/linux_ptrace_dumper.cc 
+    breakpad/src/client/linux/minidump_writer/minidump_writer.cc 
+    breakpad/src/client/linux/handler/minidump_descriptor.cc 
+    breakpad/src/client/linux/handler/exception_handler.cc 
+    breakpad/src/common/linux/guid_creator.cc 
+    breakpad/src/common/linux/file_id.cc 
+    breakpad/src/common/linux/elfutils.cc 
+    breakpad/src/common/linux/memory_mapped_file.cc 
+    breakpad/src/common/linux/safe_readlink.cc 
+    breakpad/src/common/linux/linux_libc_support.cc
+    breakpad/src/common/linux/elf_core_dump.cc
+    #breakpad/src/common/linux/elf_core_dump.cc
+
+	#crash sender
+        #breakpad/src/common/linux/google_crashdump_uploader.cc
+)
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+
+

--- a/thirdparty/breakpad/cmake/WindowsBreakpad.cmake
+++ b/thirdparty/breakpad/cmake/WindowsBreakpad.cmake
@@ -13,7 +13,3 @@ set(LIBS
     ${LIBS}
     wininet.lib
     )
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
-
-

--- a/thirdparty/breakpad/cmake/WindowsBreakpad.cmake
+++ b/thirdparty/breakpad/cmake/WindowsBreakpad.cmake
@@ -1,0 +1,20 @@
+set(SRCS
+	breakpad/src/client/windows/handler/exception_handler.cc 
+	breakpad/src/client/windows/crash_generation/crash_generation_client.cc 
+	breakpad/src/common/windows/guid_string.cc
+
+	#crash sender
+	breakpad/src/client/windows/sender/crash_report_sender.cc
+	breakpad/src/common/windows/http_upload.cc
+)
+
+add_definitions("-DUNICODE")
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
+
+add_library(breakpad SHARED ${SRCS})
+
+target_include_directories(breakpad PUBLIC
+    "${PROJECT_SOURCE_DIR}/breakpad/src/"
+)
+
+target_link_libraries(breakpad wininet.lib)

--- a/thirdparty/breakpad/cmake/WindowsBreakpad.cmake
+++ b/thirdparty/breakpad/cmake/WindowsBreakpad.cmake
@@ -1,4 +1,5 @@
 set(SRCS
+        ${SRCS}
 	breakpad/src/client/windows/handler/exception_handler.cc 
 	breakpad/src/client/windows/crash_generation/crash_generation_client.cc 
 	breakpad/src/common/windows/guid_string.cc
@@ -8,13 +9,11 @@ set(SRCS
 	breakpad/src/common/windows/http_upload.cc
 )
 
-add_definitions("-DUNICODE")
+set(LIBS
+    ${LIBS}
+    wininet.lib
+    )
+
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)
 
-add_library(breakpad SHARED ${SRCS})
 
-target_include_directories(breakpad PUBLIC
-    "${PROJECT_SOURCE_DIR}/breakpad/src/"
-)
-
-target_link_libraries(breakpad wininet.lib)


### PR DESCRIPTION
This pull request adds breakpad, a utility for handling and submitting crashes, and a crash handler which is the ui for indicating a crash happened and submitting reports. Crashes are caught and collected by breakpad, which generates minidump files containing crash information, then a callback executes the crash handler application that prompts the user to submit the crash report.

The crash report server used is https://github.com/acrisci/simple-breakpad-server.