### PR TITLE
Animated Shader and Transparency Fix

### DIFF
--- a/irisgl/assets/shaders/surface.frag
+++ b/irisgl/assets/shaders/surface.frag
@@ -31,6 +31,8 @@ in vec4 FragPosLightSpace;
 uniform sampler2D u_shadowMap;
 uniform bool u_shadowEnabled;
 
+uniform float u_time;
+
 float SampleShadowMap(sampler2D shadowMap, vec2 coords, float compare) {
     return step(compare, texture(shadowMap, coords.xy).r);
 }

--- a/irisgl/src/graphics/forwardrenderer.cpp
+++ b/irisgl/src/graphics/forwardrenderer.cpp
@@ -575,6 +575,8 @@ void ForwardRenderer::renderNode(RenderData* renderData, ScenePtr scene)
             program->setUniformValue("u_viewMatrix",    renderData->viewMatrix);
             program->setUniformValue("u_projMatrix",    renderData->projMatrix);
 
+			program->setUniformValue("u_time", scene->getRunningTime());
+
             if  (item->mesh->hasSkeleton()) {
                 auto boneTransforms = item->mesh->getSkeleton()->boneTransforms;
                 program->setUniformValueArray("u_bones", boneTransforms.data(), boneTransforms.size());

--- a/irisgl/src/scenegraph/meshnode.cpp
+++ b/irisgl/src/scenegraph/meshnode.cpp
@@ -116,6 +116,7 @@ void MeshNode::submitRenderItems()
 
         if (!!material) {
             renderItem->renderLayer = material->renderLayer;
+			renderItem->renderStates = material->renderStates;
         }
 
         this->scene->geometryRenderList->add(renderItem);

--- a/irisgl/src/scenegraph/scene.cpp
+++ b/irisgl/src/scenegraph/scene.cpp
@@ -67,6 +67,8 @@ Scene::Scene()
     geometryRenderList = new RenderList();
     shadowRenderList = new RenderList();
     gizmoRenderList = new RenderList();
+
+	time = 0;
 }
 
 void Scene::setSkyTexture(Texture2DPtr tex)
@@ -104,6 +106,7 @@ void Scene::updateSceneAnimation(float time)
 
 void Scene::update(float dt)
 {
+	time += dt;
     rootNode->update(dt);
 
     // cameras aren't always a part of the scene hierarchy, so their matrices are updated here

--- a/irisgl/src/scenegraph/scene.h
+++ b/irisgl/src/scenegraph/scene.h
@@ -86,6 +86,9 @@ public:
     int outlineWidth;
     QColor outlineColor;
 
+	// time counter to pass to shaders that do time-based animation
+	float time;
+
     Scene();
 public:
     static ScenePtr create();
@@ -103,6 +106,11 @@ public:
     void setSkyTextureSource(QString src) {
         skyTexture->source = src;
     }
+
+	float getRunningTime()
+	{
+		return time;
+	}
 
     QString getSkyTextureSource();
     void clearSkyTexture();


### PR DESCRIPTION
Added a time variable to shaders so they can support time-based animations
Fixed bug causing transparent materials to appear solid