### PR TITLE
Quick Fixes for 0.5 Release

### DIFF
--- a/irisgl/src/core/irisutils.h
+++ b/irisgl/src/core/irisutils.h
@@ -26,11 +26,11 @@ public:
         QDir basePath = QDir(QCoreApplication::applicationDirPath());
     // #if defined(WIN32) && defined(QT_DEBUG)
     //     basePath.cdUp();
-		#if defined(Q_OS_MAC)
-			basePath.cdUp();
-			basePath.cdUp();
-			basePath.cdUp();
-		#endif
+//		#if defined(Q_OS_MAC)
+//			basePath.cdUp();
+//			basePath.cdUp();
+//			basePath.cdUp();
+//		#endif
         auto path = QDir::cleanPath(basePath.absolutePath() + QDir::separator() + relToApp);
         return path;
     }

--- a/irisgl/src/vr/vrdevice.cpp
+++ b/irisgl/src/vr/vrdevice.cpp
@@ -35,6 +35,7 @@ struct VrFrameData
 VrTouchController::VrTouchController(int index)
 {
     this->index = index;
+	this->isBeingTracked = false;
 }
 
 bool VrTouchController::isButtonDown(VrTouchInput btn)


### PR DESCRIPTION
Quick fixes:
- Fixed bug that caused the user to jump to a random position when they enter vr mode. It was caused by a bool that detects the tracking state for the vr controllers not being initialized.
- Fixed the bug where asset aren't found on OSX. 