### PR TITLE
Mouse Controls

### DIFF
--- a/src/dialogs/preferences/worldsettings.cpp
+++ b/src/dialogs/preferences/worldsettings.cpp
@@ -52,6 +52,7 @@ WorldSettings::WorldSettings(Database *handle, SettingsManager* settings) :
     connect(ui->showFPS,        SIGNAL(toggled(bool)),          SLOT(showFpsChanged(bool)));
 	connect(ui->autoSave,       SIGNAL(toggled(bool)),          SLOT(enableAutoSave(bool)));
 	connect(ui->openInPlayer,   SIGNAL(toggled(bool)),          SLOT(enableOpenInPlayer(bool)));
+	connect(ui->mouseControls,	SIGNAL(currentTextChanged(const QString&)),	SLOT(mouseControlChanged(const QString&)));
 
 	QButtonGroup *buttonGroup = new QButtonGroup;
 
@@ -89,6 +90,7 @@ WorldSettings::WorldSettings(Database *handle, SettingsManager* settings) :
 
     setupDirectoryDefaults();
     setupOutline();
+	setupMouseControls();
 
 	showFps = settings->getValue("show_fps", false).toBool();
 	ui->showFPS->setChecked(showFps);
@@ -109,6 +111,22 @@ void WorldSettings::setupOutline()
 
     ui->outlineWidth->setValue(outlineWidth);
     ui->outlineColor->setColor(outlineColor);
+}
+
+void WorldSettings::setupMouseControls()
+{
+	// mouse control options
+	QList<QString> mouseControlModes;
+	mouseControlModes.append("Jahshaka");
+	mouseControlModes.append("Default");
+
+	ui->mouseControls->addItems(mouseControlModes);
+
+	auto mode = settings->getValue("mouse_controls", "jahshaka").toString();
+	if (mode == "jahshaka")
+		ui->mouseControls->setCurrentIndex(0);
+	else
+		ui->mouseControls->setCurrentIndex(1);
 }
 
 void WorldSettings::changeDefaultDirectory()
@@ -150,6 +168,15 @@ void WorldSettings::enableOpenInPlayer(bool state)
 void WorldSettings::enableAutoUpdate(bool state)
 {
 	settings->setValue("open_in_player", autoUpdate = state);
+}
+
+void WorldSettings::mouseControlChanged(const QString& value)
+{
+	qDebug() << "mouse controls: " << value;
+	if (value == "Jahshaka")
+		settings->setValue("mouse_controls", "jahshaka");
+	else
+		settings->setValue("mouse_controls", "default");
 }
 
 void WorldSettings::projectDirectoryChanged(QString path)

--- a/src/dialogs/preferences/worldsettings.h
+++ b/src/dialogs/preferences/worldsettings.h
@@ -42,6 +42,7 @@ public:
 
     void setupDirectoryDefaults();
     void setupOutline();
+	void setupMouseControls();
 
 private slots:
     void outlineWidthChanged(double width);
@@ -54,6 +55,7 @@ private slots:
     void changeEditorPath();
     void editorPathChanged(QString path);
 	void enableAutoUpdate(bool state);
+	void mouseControlChanged(const QString& value);
 
 public slots:
 	void saveSettings();

--- a/src/dialogs/preferences/worldsettings.ui
+++ b/src/dialogs/preferences/worldsettings.ui
@@ -519,6 +519,20 @@ QComboBox::down-arrow:!enabled {
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_13">
+         <item>
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Mouse Controls</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="mouseControls"/>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_4">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/editor/cameracontrollerbase.cpp
+++ b/src/editor/cameracontrollerbase.cpp
@@ -10,6 +10,14 @@ For more information see the LICENSE file
 *************************************************************************/
 
 #include "cameracontrollerbase.h"
+#include "core/settingsmanager.h"
+
+
+CameraControllerBase::CameraControllerBase()
+{
+	resetMouseStates();
+	settings = SettingsManager::getDefaultManager();
+}
 
 void CameraControllerBase::setCamera(QSharedPointer<iris::CameraNode>  cam)
 {

--- a/src/editor/cameracontrollerbase.h
+++ b/src/editor/cameracontrollerbase.h
@@ -20,13 +20,11 @@ namespace iris
     class CameraNode;
 }
 
+class SettingsManager;
 class CameraControllerBase
 {
 public:
-    CameraControllerBase()
-    {
-        resetMouseStates();
-    }
+	CameraControllerBase();
 
     virtual void setCamera(QSharedPointer<iris::CameraNode>  cam);
 
@@ -46,6 +44,8 @@ public:
 
 protected:
     QSharedPointer<iris::CameraNode> camera;
+
+	SettingsManager* settings;
 
     bool leftMouseDown;
     bool middleMouseDown;

--- a/src/editor/editorcameracontroller.cpp
+++ b/src/editor/editorcameracontroller.cpp
@@ -16,16 +16,22 @@ For more information see the LICENSE file
 #include <qmath.h>
 #include <math.h>
 #include "../core/keyboardstate.h"
+#include "../core/settingsmanager.h"
+#include "../widgets/sceneviewwidget.h"
+#include "../editor/gizmo.h"
 
 using namespace iris;
 
-EditorCameraController::EditorCameraController()
+EditorCameraController::EditorCameraController(SceneViewWidget* sceneWidget):
+	CameraControllerBase()
 {
     lookSpeed = 200;
     linearSpeed = 0.4f;
 
     yaw = 0;
     pitch = 0;
+
+	this->sceneWidget = sceneWidget;
 }
 
 CameraNodePtr EditorCameraController::getCamera()
@@ -121,7 +127,7 @@ void EditorCameraController::onMouseMove(int x,int y)
         this->pitch += y/10.0f;
     }
 
-    if(middleMouseDown)
+    if(middleMouseDown || canLeftMouseDrag())
     {
         //translate camera
         float dragSpeed = 0.01f;
@@ -144,6 +150,21 @@ void EditorCameraController::onMouseMove(int x,int y)
     */
 
     updateCameraRot();
+}
+
+bool EditorCameraController::canLeftMouseDrag()
+{
+	
+	bool gizmoDragging = false;
+	auto gizmo = sceneWidget->getActiveGizmo();
+	if (gizmo != nullptr) {
+		if (gizmo->isDragging())
+			gizmoDragging = true;
+	}
+
+	return (leftMouseDown && // left mouse must be down
+		settings->getValue("mouse_controls", "jahshaka").toString() == "jahshaka" && // left mouse to drag in jahshaka mouse mode
+		!gizmoDragging); // cant pan while dragging gizmo
 }
 
 void EditorCameraController::onMouseWheel(int delta)

--- a/src/editor/editorcameracontroller.cpp
+++ b/src/editor/editorcameracontroller.cpp
@@ -188,19 +188,19 @@ void EditorCameraController::update(float dt)
 
     auto camPos = camera->getLocalPos();
     // left
-    if(KeyboardState::isKeyDown(Qt::Key_Left) ||KeyboardState::isKeyDown(Qt::Key_A) )
+    if(KeyboardState::isKeyDown(Qt::Key_Left))
         camPos -= x * linearSpeed;
 
     // right
-    if(KeyboardState::isKeyDown(Qt::Key_Right) ||KeyboardState::isKeyDown(Qt::Key_D) )
+    if(KeyboardState::isKeyDown(Qt::Key_Right))
         camPos += x * linearSpeed;
 
     // up
-    if(KeyboardState::isKeyDown(Qt::Key_Up) ||KeyboardState::isKeyDown(Qt::Key_W) )
+    if(KeyboardState::isKeyDown(Qt::Key_Up))
         camPos += z * linearSpeed;
 
     // down
-    if(KeyboardState::isKeyDown(Qt::Key_Down) ||KeyboardState::isKeyDown(Qt::Key_S) )
+    if(KeyboardState::isKeyDown(Qt::Key_Down))
         camPos -= z * linearSpeed;
 
     camera->setLocalPos(camPos);

--- a/src/editor/editorcameracontroller.h
+++ b/src/editor/editorcameracontroller.h
@@ -22,6 +22,7 @@ namespace iris
     class CameraNode;
 }
 
+class SceneViewWidget;
 class EditorCameraController : public CameraControllerBase
 {
     QSharedPointer<iris::CameraNode> camera;
@@ -32,8 +33,10 @@ class EditorCameraController : public CameraControllerBase
     float yaw;
     float pitch;
 
+	SceneViewWidget* sceneWidget;
+
 public:
-    EditorCameraController();
+    EditorCameraController(SceneViewWidget* sceneWidget);
 
     QSharedPointer<iris::CameraNode>  getCamera();
     void setCamera(QSharedPointer<iris::CameraNode>  cam) override;
@@ -60,6 +63,8 @@ public:
     void updateCameraRot();
 
     void update(float dt);
+
+	bool canLeftMouseDrag();
 };
 
 #endif // EDITORCAMERACONTROLLER_H

--- a/src/editor/orbitalcameracontroller.h
+++ b/src/editor/orbitalcameracontroller.h
@@ -26,6 +26,7 @@ namespace iris
     class CameraNode;
 }
 
+class SceneViewWidget;
 class OrbitalCameraController:public CameraControllerBase
 {
 public:
@@ -43,12 +44,14 @@ public:
 
     float rotationSpeed;
 
+	SceneViewWidget* sceneWidget;
+
     QVector3D pivot;
     float distFromPivot;
 
 	iris::CameraNodePtr camera;
 
-    OrbitalCameraController();
+    OrbitalCameraController(SceneViewWidget* sceneWidget);
 
     iris::CameraNodePtr  getCamera();
     void setRotationSpeed(float rotationSpeed);
@@ -65,6 +68,8 @@ public:
 	void focusOnNode(iris::SceneNodePtr sceneNode);
 
     void updateCameraRot();
+
+	bool canLeftMouseDrag();
 };
 
 #endif // ORBITALCAMERACONTROLLER_H

--- a/src/widgets/assetviewer.cpp
+++ b/src/widgets/assetviewer.cpp
@@ -144,8 +144,8 @@ void AssetViewer::initializeGL()
     m->setValue("textureScale", 4.f);
     node->setMaterial(m);
 
-    defaultCam = new EditorCameraController();
-    orbitalCam = new OrbitalCameraController();
+    defaultCam = new EditorCameraController(nullptr);
+    orbitalCam = new OrbitalCameraController(nullptr);
 	orbitalCam->previewMode = true;
 
     camera = iris::CameraNode::create();

--- a/src/widgets/sceneviewwidget.cpp
+++ b/src/widgets/sceneviewwidget.cpp
@@ -250,8 +250,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 
     viewport = new iris::Viewport();
 
-    defaultCam = new EditorCameraController();
-    orbitalCam = new OrbitalCameraController();
+    defaultCam = new EditorCameraController(this);
+    orbitalCam = new OrbitalCameraController(this);
     viewerCam = new ViewerCameraController();
 
     camController = defaultCam;
@@ -280,6 +280,8 @@ SceneViewWidget::SceneViewWidget(QWidget *parent) : QOpenGLWidget(parent)
 
     fontSize = 20;
     showFps = SettingsManager::getDefaultManager()->getValue("show_fps", false).toBool();
+
+	settings = SettingsManager::getDefaultManager();
 }
 
 void SceneViewWidget::resetEditorCam()
@@ -779,6 +781,24 @@ void SceneViewWidget::mouseMoveEvent(QMouseEvent *e)
 	gizmo->updateSize(editorCam);
 }
 
+void SceneViewWidget::mouseDoubleClickEvent(QMouseEvent * e)
+{
+	auto lastSelected = selectedNode;
+
+	if (e->button() == Qt::LeftButton) {
+		editorCam->updateCameraMatrices();
+
+		if (viewportMode == ViewportMode::Editor && UiManager::sceneMode == SceneMode::EditMode) {
+			if (selectedNode.isNull()) {
+				// double-click to select object
+				if (settings->getValue("mouse_controls", "jahshaka").toString() == "jahshaka") {
+					this->doObjectPicking(e->localPos(), lastSelected);
+				}
+			}
+		}
+	}
+}
+
 void SceneViewWidget::mousePressEvent(QMouseEvent *e)
 {
     auto lastSelected = selectedNode;
@@ -802,7 +822,9 @@ void SceneViewWidget::mousePressEvent(QMouseEvent *e)
 
             // if we don't have a selected node, prioritize object picking
             if (selectedNode.isNull()) {
-                this->doObjectPicking(e->localPos(), lastSelected);
+				if (settings->getValue("mouse_controls", "jahshaka").toString() == "default") {
+					this->doObjectPicking(e->localPos(), lastSelected);
+				}
             }
         }
     }

--- a/src/widgets/sceneviewwidget.h
+++ b/src/widgets/sceneviewwidget.h
@@ -152,6 +152,10 @@ public:
     void setGizmoLoc();
     void setGizmoRot();
     void setGizmoScale();
+	Gizmo* getActiveGizmo()
+	{
+		return gizmo;
+	}
 
     void setEditorData(EditorData* data);
     EditorData* getEditorData();
@@ -167,6 +171,7 @@ public:
     QVector3D calculateMouseRay(const QPointF& pos);
     void mousePressEvent(QMouseEvent* evt);
     void mouseMoveEvent(QMouseEvent* evt);
+	void mouseDoubleClickEvent(QMouseEvent* evt);
 
 	iris::SceneNodePtr savedActiveNode;
 	iris::CustomMaterialPtr originalMaterial;
@@ -292,6 +297,7 @@ private:
 	bool displaySelectionOutline;
 
 	AnimationPath* animPath;
+	SettingsManager* settings;
 
 signals:
     void addDroppedMesh(QString, bool, QVector3D, QString, QString);


### PR DESCRIPTION
There are two types of mouse controls in jahshaka now, "Jahshaka" and "Default". The only difference between the two is that in Default you select an object with the left mouse button and pan with the middle mouse button, while in Jahshaka mode you select objects by double clicking with the left mouse button and pan by dragging the left mouse button.